### PR TITLE
Add abort()

### DIFF
--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -148,6 +148,11 @@
           var chunk, i, length, payload,
               binary = '';
 
+          if (!buffer.length) {
+            // do nothing if the buffer is empty
+            return;
+          }
+
           // concatenate appends up to the max append size
           payload = new Uint8Array(Math.min(videojs.MediaSource.MAX_APPEND_SIZE, bufferSize));
           i = payload.byteLength;
@@ -201,6 +206,12 @@
 
       buffer.push(uint8Array);
       bufferSize += uint8Array.byteLength;
+    };
+
+    // reset the parser and remove any data queued to be sent to the swf
+    this.abort = function() {
+      buffer = [];
+      bufferSize = 0;
     };
   };
   videojs.SourceBuffer.prototype = new EventEmitter();

--- a/test/media-sources_test.js
+++ b/test/media-sources_test.js
@@ -114,4 +114,13 @@
     strictEqual(timers.length, 0, 'no more appends are scheduled');
 
   });
+
+  test('abort() clears any buffered input', function() {
+    var sourceBuffer = mediaSource.addSourceBuffer('video/flv');
+    sourceBuffer.appendBuffer(new Uint8Array([0]));
+    sourceBuffer.abort();
+
+    timers.pop()();
+    strictEqual(swfCalls.length, 0, 'made no appends');
+  });
 })(window, window.document, window.videojs);


### PR DESCRIPTION
When implementing `seek` in particulary, it is necessary to flush any video data that hasn't yet been delivered to the SWF. Add [abort()](https://dvcs.w3.org/hg/html-media/raw-file/tip/media-source/media-source.html#widl-SourceBuffer-abort-void) on SourceBuffer to allow this.
