### PR TITLE
use setTimeout instead of requestAnimationFrame when the page is hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ If you'd like to play higher bitrate content, you can adjust that setting:
 
 ```javascript
 // 8MB/s at 60fps
-videojs.MediaSource.MAX_APPEND_SIZE = Math.ceil((8 * 1024 * 1024) / 60);
+videojs.MediaSource.BYTES_PER_SECOND_GOAL = 8 * 1024 * 1024;
 ```
-Setting the `MAX_APPEND_SIZE` too high may lead to dropped frames during playback on slower computers.
+Setting the `BYTES_PER_SECOND_GOAL` too high may lead to dropped frames during playback on slower computers.
 
 Check out an example of the plugin in use in [example.html](example.html).
 

--- a/test/media-sources_test.js
+++ b/test/media-sources_test.js
@@ -1,17 +1,17 @@
 (function(window, document, videojs) {
   'use strict';
-  var player, video, mediaSource, oldRAF, oldCanPlay, oldFlashSupport, oldMaxAppend,
+  var player, video, mediaSource, oldRFA, oldCanPlay, oldFlashSupport, oldBPS,
       swfCalls,
       timers,
-      fakeRAF = function() {
-        oldRAF = window.requestAnimationFrame;
+      fakeRFA = function() {
+        oldRFA = window.requestAnimationFrame;
         timers = [];
         window.requestAnimationFrame = function(callback) {
           timers.push(callback);
         };
       },
-      unfakeRAF = function() {
-        window.requestAnimationFrame = oldRAF;
+      unfakeRFA = function() {
+        window.setTimeout = oldRFA;
       };
 
   module('SourceBuffer', {
@@ -22,7 +22,7 @@
         return true;
       };
 
-      oldMaxAppend = videojs.MediaSource.MAX_APPEND_SIZE;
+      oldBPS = videojs.MediaSource.BYTES_PER_SECOND_GOAL;
 
       video = document.createElement('video');
       document.getElementById('qunit-fixture').appendChild(video);
@@ -44,13 +44,13 @@
       });
       mediaSource.trigger('sourceopen');
 
-      fakeRAF();
+      fakeRFA();
     },
     teardown: function() {
       videojs.Flash.isSupported = oldFlashSupport;
       videojs.Flash.canPlaySource = oldCanPlay;
-      videojs.MediaSource.MAX_APPEND_SIZE = oldMaxAppend;
-      unfakeRAF();
+      videojs.MediaSource.BYTES_PER_SECOND_GOAL = oldBPS;
+      unfakeRFA();
     }
   });
 
@@ -89,7 +89,7 @@
 
   test('splits appends that are bigger than the maximum configured size', function() {
     var sourceBuffer = mediaSource.addSourceBuffer('video/flv');
-    videojs.MediaSource.MAX_APPEND_SIZE = 1;
+    videojs.MediaSource.BYTES_PER_SECOND_GOAL = 60;
 
     sourceBuffer.appendBuffer(new Uint8Array([0,1]));
     sourceBuffer.appendBuffer(new Uint8Array([2,3]));


### PR DESCRIPTION
Since browsers expect requestAnimationFrame to be used for visual animations,
they feel free to scale down the rate at which requestAnimationFrame is invoked
when they think the user isn't looking. For example, In a background tab, Chrome
stops invoking the callback completely while Firefox throttles it to once a
second. This starves a playing video of data in a background tab. To address
that problem, this patch switches the usage of requestAnimationFrame to
setTimeout at 60 FPS.

Now, setTimeout is also throttled in a background tab (but thankfully not
completely turned off). When we're only getting one callback a second, appending
only one 1/60 of a second's data each tick quickly stalls the player. Therefore,
this patch changes the append function, so that it just appends a whole second
worth of data if it thinks its being throttled. This is admittedly a rather ugly
solution. I also tried estimating the current "FPS" of setTimeout to calculate
how much to append at each tick get to the per-second append goal. However, that
seemed to work worse than this simpler solution, partially because it caused a
feedback loop where larger appends led to longer setTimeout intervals.