### PR TITLE
Changed to safely call  SWF functions for disposing videojs

### DIFF
--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -187,10 +187,12 @@
 
           // bypass normal ExternalInterface calls and pass xml directly
           // EI can be slow by default
-          self.source.swfObj.CallFunction('<invoke name="vjs_appendBuffer"' +
-                                          'returntype="javascript"><arguments><string>' +
-                                          b64str +
-                                          '</string></arguments></invoke>');
+          if (self.source.swfObj.vjs_appendBuffer !== undefined) {
+            self.source.swfObj.CallFunction('<invoke name="vjs_appendBuffer"' +
+                                            'returntype="javascript"><arguments><string>' +
+                                            b64str +
+                                            '</string></arguments></invoke>');
+          }
           };
 
     videojs.SourceBuffer.prototype.init.call(this);
@@ -212,7 +214,9 @@
     this.abort = function() {
       buffer = [];
       bufferSize = 0;
-      this.source.swfObj.vjs_abort();
+      if (this.source.swfObj.vjs_abort !== undefined) {
+        this.source.swfObj.vjs_abort();
+      }
     };
   };
   videojs.SourceBuffer.prototype = new EventEmitter();

--- a/test/media-sources_test.js
+++ b/test/media-sources_test.js
@@ -34,6 +34,8 @@
         CallFunction: function(xml) {
           swfCalls.push(xml);
         },
+        vjs_appendBuffer: function() {
+        },
         vjs_abort: function() {
           swfCalls.push('abort');
         }


### PR DESCRIPTION
The media-source plugin calls SWF functions and I got an error when I have called videojs.dispose() as below. I confirmed with videojs-4.8.2, videojs-swf-4.4.3, videojs-contrilb-hls-plugin-0.9.0 and videojs-contrib-media-source-0.3.0 on IE10, IE11 and Chrome35, but it didn't occurred on Firefox31 somehow. I think it should be call after checking those function's existence.

```js
TypeError: undefined is not a function
    at abort (http://path/to/videojs-media-sources.js:217:26)
    at videojs.Hls.dispose (http://path/to/videojs.hls.js:247:23)
    at vjs.Player.dispose (http://path/to/video.dev.js:3448:30)
    ...
```
