### PR TITLE
Use setTimeout instead of requestAnimationFrame

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
   - "0.10"
+before_script:
+- npm install -g grunt-cli

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ If you'd like to play higher bitrate content, you can adjust that setting:
 
 ```javascript
 // 8MB/s at 60fps
-videojs.MediaSource.MAX_APPEND_SIZE = Math.ceil((8 * 1024 * 1024) / 60);
+videojs.MediaSource.BYTES_PER_SECOND_GOAL = 8 * 1024 * 1024;
 ```
-Setting the `MAX_APPEND_SIZE` too high may lead to dropped frames during playback on slower computers.
+Setting the `BYTES_PER_SECOND_GOAL` too high may lead to dropped frames during playback on slower computers.
 
 Check out an example of the plugin in use in [example.html](example.html).
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Media Source Extensions plugin for video.js",
   "main": "videojs-media-sources.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "grunt"
   },
   "repository": {
     "type": "git",

--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -162,7 +162,7 @@
             scheduleTick(append);
           }
         },
-        append = function() {4
+        append = function() {
           var chunk, i, length, payload, maxSize,
               binary = '';
 

--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -4,21 +4,7 @@
       nativeUrl = window.URL || {},
       EventEmitter,
       flvCodec = /video\/flv(;\s*codecs=["']vp6,aac["'])?$/,
-      objectUrlPrefix = 'blob:vjs-media-source/',
-
-      /**
-       * Polyfill for requestAnimationFrame
-       * @param callback {function} the function to run at the next frame
-       * @see https://developer.mozilla.org/en-US/docs/Web/API/window.requestAnimationFrame
-       */
-      requestAnimationFrame = function(callback) {
-        return (window.requestAnimationFrame ||
-                window.webkitRequestAnimationFrame ||
-                window.mozRequestAnimationFrame ||
-                function(callback) {
-                  return window.setTimeout(callback, 1000 / 60);
-                })(callback);
-      };
+      objectUrlPrefix = 'blob:vjs-media-source/';
 
   EventEmitter = function(){};
   EventEmitter.prototype.init = function(){
@@ -146,21 +132,10 @@
         // the total number of queued bytes
         bufferSize = 0,
         scheduleTick = function(func) {
-          if (document.hidden) {
-            // Chrome doesn't invoke requestAnimationFrame callbacks
-            // in background tabs, so use setTimeout.
-            window.setTimeout(func, Math.ceil(1000/videojs.MediaSource.TICKS_PER_SECOND));
-          } else {
-            requestAnimationFrame(func);
-          }
-        },
-        onVisibilityChange = function() {
-          // If the document just became hidden, requestAnimationFrame
-          // may not be ever called, so schedule the tick using
-          // setTimeout.
-          if (document.hidden && buffer.length > 0) {
-            scheduleTick(append);
-          }
+          // Chrome doesn't invoke requestAnimationFrame callbacks
+          // in background tabs, so use setTimeout.
+          window.setTimeout(func,
+                            Math.ceil(1000 / videojs.MediaSource.TICKS_PER_SECOND));
         },
         append = function() {
           var chunk, i, length, payload, maxSize,
@@ -204,9 +179,7 @@
           // schedule another append if necessary
           if (bufferSize !== 0) {
             scheduleTick(append);
-            document.addEventListener("visibilitychange", onVisibilityChange);
           } else {
-            document.removeEventListener("visibilitychange", onVisibilityChange);
             self.trigger({ type: 'updateend' });
           }
 

--- a/test/media-sources_test.js
+++ b/test/media-sources_test.js
@@ -1,17 +1,22 @@
 (function(window, document, videojs) {
   'use strict';
-  var player, video, mediaSource, oldRFA, oldCanPlay, oldFlashSupport, oldBPS,
+  var player, video, mediaSource, oldSTO, oldRFA, oldCanPlay, oldFlashSupport, oldBPS,
       swfCalls,
       timers,
       fakeRFA = function() {
         oldRFA = window.requestAnimationFrame;
+        oldSTO = window.setTimeout;
         timers = [];
         window.requestAnimationFrame = function(callback) {
           timers.push(callback);
         };
+        window.setTimeout = function(callback) {
+          timers.push(callback);
+        };
       },
       unfakeRFA = function() {
-        window.setTimeout = oldRFA;
+        window.setTimeout = oldSTO;
+        window.requestAnimationFrame = oldRFA;
       };
 
   module('SourceBuffer', {

--- a/test/media-sources_test.js
+++ b/test/media-sources_test.js
@@ -1,17 +1,17 @@
 (function(window, document, videojs) {
   'use strict';
-  var player, video, mediaSource, oldRAF, oldCanPlay, oldFlashSupport, oldMaxAppend,
+  var player, video, mediaSource, oldRFA, oldCanPlay, oldFlashSupport, oldBPS,
       swfCalls,
       timers,
-      fakeRAF = function() {
-        oldRAF = window.requestAnimationFrame;
+      fakeRFA = function() {
+        oldRFA = window.requestAnimationFrame;
         timers = [];
         window.requestAnimationFrame = function(callback) {
           timers.push(callback);
         };
       },
-      unfakeRAF = function() {
-        window.requestAnimationFrame = oldRAF;
+      unfakeRFA = function() {
+        window.setTimeout = oldRFA;
       };
 
   module('SourceBuffer', {
@@ -22,7 +22,7 @@
         return true;
       };
 
-      oldMaxAppend = videojs.MediaSource.MAX_APPEND_SIZE;
+      oldBPS = videojs.MediaSource.BYTES_PER_SECOND_GOAL;
 
       video = document.createElement('video');
       document.getElementById('qunit-fixture').appendChild(video);
@@ -44,13 +44,13 @@
       });
       mediaSource.trigger('sourceopen');
 
-      fakeRAF();
+      fakeRFA();
     },
     teardown: function() {
       videojs.Flash.isSupported = oldFlashSupport;
       videojs.Flash.canPlaySource = oldCanPlay;
-      videojs.MediaSource.MAX_APPEND_SIZE = oldMaxAppend;
-      unfakeRAF();
+      videojs.MediaSource.BYTES_PER_SECOND_GOAL = oldBPS;
+      unfakeRFA();
     }
   });
 
@@ -89,7 +89,7 @@
 
   test('splits appends that are bigger than the maximum configured size', function() {
     var sourceBuffer = mediaSource.addSourceBuffer('video/flv');
-    videojs.MediaSource.MAX_APPEND_SIZE = 1;
+    videojs.MediaSource.BYTES_PER_SECOND_GOAL = 60;
 
     sourceBuffer.appendBuffer(new Uint8Array([0,1]));
     sourceBuffer.appendBuffer(new Uint8Array([2,3]));


### PR DESCRIPTION
#15 changed back to just use setTimeout(). Swapping between requestAnimationFrame() and setTimeout() is nice but I don't think the benefit it adds is worth the additional code complexity. Added travis support and fixed up tests in phantomjs.