### PR TITLE
Throttle updating

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-contrib-media-sources",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A Media Source Extensions plugin for video.js",
   "main": "videojs-media-sources.js",
   "scripts": {


### PR DESCRIPTION
HTML5 SourceBuffers do not allow appends while an update is in progress. We don't have a coded frame processing loop to run but we do asynchronously shuttle bytes into the object tag. Throw an error if updates are requested during that period. Expose the updating property on SourceBuffers for convenient querying.