### PR TITLE
Allow codecs to be passed into source buffer creation

### DIFF
--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -76,12 +76,12 @@
   };
 
   addSourceBuffer = function(type) {
-    var audio, video, buffer, match;
+    var audio, video, buffer, codecs;
     // create a virtual source buffer to transmux MPEG-2 transport
     // stream segments into fragmented MP4s
     if ((/^video\/mp2t/i).test(type)) {
-      match = (/codecs=['"]?([^'"]*)['"]?$/i).exec(type);
-      buffer = new VirtualSourceBuffer(this, match && match[1]);
+      codecs = type.split(';').slice(1).join(';');
+      buffer = new VirtualSourceBuffer(this, codecs);
       this.virtualBuffers.push(buffer);
       return buffer;
     }
@@ -122,7 +122,7 @@
               // Some common mp4 codec strings. Saved for future twittling:
               // 4d400d
               // 42c01e & 42c01f
-              self.videoBuffer_ = mediaSource.addSourceBuffer_('video/mp4;codecs=' + (codecs || 'avc1.4d400d'));
+              self.videoBuffer_ = mediaSource.addSourceBuffer_('video/mp4;' + (codecs || 'codecs=avc1.4d400d'));
               // aggregate buffer events
               self.videoBuffer_.addEventListener('updatestart',
                                                  aggregateUpdateHandler(self, 'audioBuffer_', 'updatestart'));
@@ -133,7 +133,7 @@
             }
           } else if (segment.type === 'audio') {
             if (!self.audioBuffer_) {
-              self.audioBuffer_ = mediaSource.addSourceBuffer_('audio/mp4;codecs=' + ( codecs || 'mp4a.40.2'));
+              self.audioBuffer_ = mediaSource.addSourceBuffer_('audio/mp4;' + (codecs || 'codecs=mp4a.40.2'));
               // aggregate buffer events
               self.audioBuffer_.addEventListener('updatestart',
                                                  aggregateUpdateHandler(self, 'videoBuffer_', 'updatestart'));
@@ -144,7 +144,7 @@
             }
           } else if (segment.type === 'combined') {
             if (!self.videoBuffer_) {
-              self.videoBuffer_ = mediaSource.addSourceBuffer_('video/mp4;codecs=' + (codecs || 'avc1.4d400d, mp4a.40.2'));
+              self.videoBuffer_ = mediaSource.addSourceBuffer_('video/mp4;' + (codecs || 'codecs=avc1.4d400d, mp4a.40.2'));
               // aggregate buffer events
               self.videoBuffer_.addEventListener('updatestart',
                                                  aggregateUpdateHandler(self, 'videoBuffer_', 'updatestart'));

--- a/test/media-sources_test.js
+++ b/test/media-sources_test.js
@@ -188,7 +188,7 @@
       }
     });
     equal(mediaSource.sourceBuffers[0].type,
-          'video/mp4;codecs=avc1.64001f,mp4a.40.5',
+          'video/mp4; codecs="avc1.64001f,mp4a.40.5"',
           'passed the codec along');
   });
 

--- a/test/media-sources_test.js
+++ b/test/media-sources_test.js
@@ -174,6 +174,42 @@
     equal(mp4Segments.length, 1, 'appended the segments');
   });
 
+  test('forwards codec strings to native buffers when specified', function() {
+    var mediaSource = new videojs.MediaSource(),
+        sourceBuffer = mediaSource.addSourceBuffer('video/mp2t; codecs="avc1.64001f,mp4a.40.5"');
+
+    sourceBuffer.transmuxer_.onmessage({
+      data: {
+        action: 'data',
+        segment: {
+          type: 'combined',
+          data: new Uint8Array(1).buffer
+        }
+      }
+    });
+    equal(mediaSource.sourceBuffers[0].type,
+          'video/mp4;codecs=avc1.64001f,mp4a.40.5',
+          'passed the codec along');
+  });
+
+  test('specifies reasonable codecs if none are specified', function() {
+    var mediaSource = new videojs.MediaSource(),
+        sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+
+    sourceBuffer.transmuxer_.onmessage({
+      data: {
+        action: 'data',
+        segment: {
+          type: 'combined',
+          data: new Uint8Array(1).buffer
+        }
+      }
+    });
+    equal(mediaSource.sourceBuffers[0].type,
+          'video/mp4;codecs=avc1.4d400d, mp4a.40.2',
+          'passed the codec along');
+  });
+
   test('virtual buffers are updating if either native buffer is', function(){
     var mediaSource = new videojs.MediaSource(),
         sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');


### PR DESCRIPTION
Some codecs (HE-AAC audio) are hard to detect ahead of time and can cause browsers to fail if they're not properly specified. Allow downstream developers to override the default codec selection if they have out-of-band information about the codecs their content uses.