### PR TITLE
Mse discontinuity

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,10 +35,10 @@ module.exports = function(grunt) {
           'node_modules/mux.js/lib/stream.js',
           'node_modules/mux.js/lib/exp-golomb.js',
           'node_modules/mux.js/legacy/flv-tag.js',
+          'node_modules/mux.js/legacy/h264-extradata.js',
           'node_modules/mux.js/legacy/aac-stream.js',
           'node_modules/mux.js/legacy/h264-stream.js',
           'node_modules/mux.js/legacy/metadata-stream.js',
-          'node_modules/mux.js/legacy/h264-extradata.js',
           'node_modules/mux.js/legacy/segment-parser.js',
           '<%= blobify.build.dest %>'
         ],

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "video.js": "^5.0.0-rc.93"
   },
   "dependencies": {
-    "mux.js": "dmlap/mux.js.git"
+    "mux.js": "videojs/mux.js.git"
   }
 }

--- a/src/transmuxer_worker.js
+++ b/src/transmuxer_worker.js
@@ -51,7 +51,7 @@ var wireTransmuxerEvents = function (transmuxer) {
 };
 
 /**
- * All incoming messages route through this hash. If not function exists
+ * All incoming messages route through this hash. If no function exists
  * to handle an incoming message, then we ignore the message.
  */
 var messageHandlers = {
@@ -70,10 +70,8 @@ var messageHandlers = {
    * default options if `init` was never explicitly called
    */
   defaultInit: function () {
-    if (!transmuxer) {
-      transmuxer = new muxjs.mp2t.Transmuxer();
-      wireTransmuxerEvents(transmuxer);
-    }
+    transmuxer = new muxjs.mp2t.Transmuxer();
+    wireTransmuxerEvents(transmuxer);
   },
   /**
    * push
@@ -81,8 +79,6 @@ var messageHandlers = {
    * processing
    */
   push: function (data) {
-    this.defaultInit();
-
     // Cast array buffer to correct type for transmuxer
     var segment = new Uint8Array(data.data);
     transmuxer.push(segment);
@@ -93,8 +89,6 @@ var messageHandlers = {
    * begin at a baseMediaDecodeTime of 0
    */
   resetBaseMediaDecodeTime: function (data) {
-    this.defaultInit();
-
     transmuxer.resetBaseMediaDecodeTime();
   },
   /**
@@ -108,6 +102,12 @@ var messageHandlers = {
 };
 
 onmessage = function(event) {
+  // Setup the default transmuxer if one doesn't exist yet and we are invoked with
+  // an action other than `init`
+  if (!transmuxer && event.data.action !== 'init') {
+    messageHandlers.defaultInit();
+  }
+
   if (event.data && event.data.action) {
     if (messageHandlers[event.data.action]) {
       messageHandlers[event.data.action](event.data);

--- a/src/transmuxer_worker.js
+++ b/src/transmuxer_worker.js
@@ -67,7 +67,7 @@ var messageHandlers = {
   flush: function (data) {
     transmuxer.flush();
   }
-}
+};
 
 onmessage = function(event) {
   var action;

--- a/src/transmuxer_worker.js
+++ b/src/transmuxer_worker.js
@@ -8,7 +8,10 @@
  * transmuxer running inside of a WebWorker by exposing a simple
  * message-based interface to a Transmuxer object.
  */
-var muxjs = {};
+var
+  muxjs = {},
+  transmuxer,
+  initOptions = {};
 
 importScripts('../node_modules/mux.js/lib/exp-golomb.js');
 importScripts('../node_modules/mux.js/lib/mp4-generator.js');
@@ -17,7 +20,6 @@ importScripts('../node_modules/mux.js/lib/metadata-stream.js');
 importScripts('../node_modules/mux.js/lib/transmuxer.js');
 importScripts('../node_modules/mux.js/lib/caption-stream.js');
 
-var transmuxer;
 
 /**
  * wireTransmuxerEvents
@@ -61,8 +63,8 @@ var messageHandlers = {
    * outside the worker
    */
   init: function (data) {
-    transmuxer = new muxjs.mp2t.Transmuxer(data && data.options);
-    wireTransmuxerEvents(transmuxer);
+    initOptions = (data && data.options) || {};
+    this.defaultInit();
   },
   /**
    * defaultInit
@@ -70,7 +72,7 @@ var messageHandlers = {
    * default options if `init` was never explicitly called
    */
   defaultInit: function () {
-    transmuxer = new muxjs.mp2t.Transmuxer();
+    transmuxer = new muxjs.mp2t.Transmuxer(initOptions);
     wireTransmuxerEvents(transmuxer);
   },
   /**
@@ -84,12 +86,13 @@ var messageHandlers = {
     transmuxer.push(segment);
   },
   /**
-   * resetBaseMediaDecodeTime
-   * Signal to the transmuxer that the next segment added via `push` should
-   * begin at a baseMediaDecodeTime of 0
+   * resetTransmuxer
+   * Recreate the transmuxer so that the next segment added via `push`
+   * begins at a baseMediaDecodeTime of 0
    */
-  resetBaseMediaDecodeTime: function (data) {
-    transmuxer.resetBaseMediaDecodeTime();
+  resetTransmuxer: function (data) {
+    // delete the transmuxer
+    this.defaultInit();
   },
   /**
    * flush

--- a/src/transmuxer_worker.js
+++ b/src/transmuxer_worker.js
@@ -17,7 +17,7 @@ importScripts('../node_modules/mux.js/lib/metadata-stream.js');
 importScripts('../node_modules/mux.js/lib/transmuxer.js');
 importScripts('../node_modules/mux.js/lib/caption-stream.js');
 
-var transmuxer;// = new muxjs.mp2t.Transmuxer();
+var transmuxer;
 
 var wireTransmuxerEvents = function (transmuxer) {
   transmuxer.on('data', function (segment) {

--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -177,7 +177,8 @@
           return;
         }
       };
-
+      // this timestampOffset is a property with the side-effect of resetting
+      // baseMediaDecodeTime in the transmuxer on the setter
       Object.defineProperty(this, 'timestampOffset', {
         get: function() {
           return this.timestampOffset_;
@@ -323,7 +324,7 @@
           offset += segment.byteLength;
         });
 
-        // Set timestampOffset if we have been given one
+        // Set timestampOffset if it was changed before this append
         if (this.timestampOffsetChanged_) {
           destinationBuffer.timestampOffset = this.timestampOffset_;
         }

--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -190,7 +190,7 @@
             this.timestampOffset_ = val;
             // We have to tell the transmuxer to reset the baseMediaDecodeTime to
             // zero for the next segment
-            this.transmuxer_.postMessage({action: 'resetBaseMediaDecodeTime'});
+            this.transmuxer_.postMessage({action: 'resetTransmuxer'});
           }
         }
       });

--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -388,7 +388,7 @@
       this.on(['sourceopen', 'webkitsourceopen'], function(event){
         // find the swf where we will push media data
         this.swfObj = document.getElementById(event.swfId);
-        this.tech_ = videojs(this.swfObj.parentNode).tech;
+        this.tech_ = videojs(this.swfObj.parentNode).tech_;
         this.readyState = 'open';
 
         this.tech_.on('seeking', function() {

--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -177,6 +177,7 @@
           return;
         }
       };
+
       // this timestampOffset is a property with the side-effect of resetting
       // baseMediaDecodeTime in the transmuxer on the setter
       Object.defineProperty(this, 'timestampOffset', {
@@ -284,6 +285,15 @@
 
       this.transmuxer_.postMessage({action: 'push', data: segment.buffer}, [segment.buffer]);
       this.transmuxer_.postMessage({action: 'flush'});
+    },
+    remove: function(start, end) {
+      if (this.videoBuffer_) {
+        this.videoBuffer_.remove(start, end);
+      }
+      if (this.audioBuffer_) {
+        this.audioBuffer_.remove(start, end);
+      }
+      // TODO: Remove TextTracks and Cues
     },
     /**
      * Process any segments that the muxer has output

--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -230,8 +230,8 @@
             ends.push(this.audioBuffer_.buffered.end(lastIndex));
           }
 
-          start = Math.max.apply(Math, starts);
-          end = Math.min.apply(Math, ends);
+          start = Math.min.apply(Math, starts);
+          end = Math.max.apply(Math, ends);
           return videojs.createTimeRange(start, end);
         }
       });

--- a/test/media-sources_test.js
+++ b/test/media-sources_test.js
@@ -401,7 +401,7 @@
         };
       }
     };
-    sourceBuffer.baseMediaDecodeTime_ = 10 * 90e3;
+    sourceBuffer.timestampOffset = 10;
     sourceBuffer.transmuxer_.onmessage({
       data: {
         action: 'data',
@@ -426,8 +426,8 @@
     equal(types[0], 'captions', 'the type was captions');
     equal(cues.length, 1, 'created one cue');
     equal(cues[0].text, 'This is an in-band caption', 'included the text');
-    equal(cues[0].startTime, 1, 'started at one');
-    equal(cues[0].endTime, 3, 'ended at three');
+    equal(cues[0].startTime, 11, 'started at eleven');
+    equal(cues[0].endTime, 13, 'ended at thirteen');
   });
 
   test('does not wrap mp4 source buffers', function(){

--- a/test/media-sources_test.js
+++ b/test/media-sources_test.js
@@ -480,8 +480,8 @@
       });
       swfObj = document.createElement('fake-object');
       swfObj.id = 'fake-swf-' + assert.test.testId;
-      player.el().replaceChild(swfObj, player.tech.el());
-      player.tech.el_ = swfObj;
+      player.el().replaceChild(swfObj, player.tech_.el());
+      player.tech_.el_ = swfObj;
       swfObj.CallFunction = function(xml) {
         swfCalls.push(xml);
       };
@@ -495,6 +495,9 @@
         swfCalls.push('load');
       };
       swfObj.vjs_setProperty = function(attr, value) {
+        swfCalls.push({ attr: attr, value: value });
+      };
+      swfObj.vjs_discontinuity = function(attr, value) {
         swfCalls.push({ attr: attr, value: value });
       };
       swfObj.vjs_appendBuffer = function(flvHeader) {
@@ -798,10 +801,10 @@
         data;
 
     // seek to 15 seconds
-    player.tech.seeking = function() {
+    player.tech_.seeking = function() {
       return true;
     };
-    player.tech.currentTime = function() {
+    player.tech_.currentTime = function() {
       return 15;
     };
     // FLV tags for this segment start at 10 seconds in the media
@@ -840,13 +843,13 @@
   test('passes endOfStream network errors to the tech', function() {
     mediaSource.endOfStream('network');
 
-    equal(player.tech.error().code, 2, 'set a network error');
+    equal(player.tech_.error().code, 2, 'set a network error');
   });
 
-  test('passes endOfStream network errors to the tech', function() {
+  test('passes endOfStream decode errors to the tech', function() {
     mediaSource.endOfStream('decode');
 
-    equal(player.tech.error().code, 3, 'set a decode error');
+    equal(player.tech_.error().code, 3, 'set a decode error');
   });
 
   module('createObjectURL');

--- a/test/media-sources_test.js
+++ b/test/media-sources_test.js
@@ -270,12 +270,21 @@
       }
     });
 
-    mediaSource.sourceBuffers[0].buffered = videojs.createTimeRange(0, 10);
-    mediaSource.sourceBuffers[1].buffered = videojs.createTimeRange(0, 7);
+    mediaSource.sourceBuffers[0].buffered = videojs.createTimeRanges([
+      [0, 10],
+      [20, 30]
+    ]);
+    mediaSource.sourceBuffers[1].buffered = videojs.createTimeRanges([
+      [0, 7],
+      [11, 15],
+      [16, 40]
+    ]);
 
-    equal(sourceBuffer.buffered.length, 1, 'one buffered range');
-    equal(sourceBuffer.buffered.start(0), 0, 'starts at zero');
-    equal(sourceBuffer.buffered.end(0), 7, 'ends at the latest shared time');
+    equal(sourceBuffer.buffered.length, 2, 'two buffered ranges');
+    equal(sourceBuffer.buffered.start(0), 0, 'first starts at zero');
+    equal(sourceBuffer.buffered.end(0), 7, 'first ends at seven');
+    equal(sourceBuffer.buffered.start(1), 20, 'second starts at twenty');
+    equal(sourceBuffer.buffered.end(1), 30, 'second ends at 30');
   });
 
   test('sets native timestamp offsets on appends', function(){


### PR DESCRIPTION
To support discontinuity we leverage the `timestampOffset` feature of MSE. Whenever a `timestampOffset` is set on our polyfill, (for example by contrib-hls) we force the transmuxer to reset the *BaseMediaDecodeTime* calculations so that the next segment will start at 0. When we receive that segment back from the transmuxer, we then set the `timestampOffset` of the real native source buffers to the value we were given and start appending segments.
