### PR TITLE
Update Flash handling for later vjs5 RCs

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "karma-firefox-launcher": "^0.1.6",
     "karma-qunit": "^0.1.5",
     "qunitjs": "^1.14.0",
-    "video.js": "^5.0.0-rc.4"
+    "video.js": "^5.0.0-rc.93"
   },
   "dependencies": {
     "mux.js": "dmlap/mux.js.git"

--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -324,7 +324,7 @@
       this.on(['sourceopen', 'webkitsourceopen'], function(event){
         // find the swf where we will push media data
         this.swfObj = document.getElementById(event.swfId);
-        this.tech_ = videojs(this.swfObj.parentNode).tech;
+        this.tech_ = this.swfObj.tech;
         this.readyState = 'open';
 
         this.tech_.on('seeking', function() {

--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -25,7 +25,7 @@
     mode: 'auto'
   };
 
-  videojs.MediaSource = videojs.extends(EventTarget, {
+  videojs.MediaSource = videojs.extend(EventTarget, {
     constructor: function(options){
       var self;
 
@@ -98,7 +98,7 @@
     };
   };
 
-  VirtualSourceBuffer = videojs.extends(EventTarget, {
+  VirtualSourceBuffer = videojs.extend(EventTarget, {
     constructor: function VirtualSourceBuffer(mediaSource, codecs) {
       var self = this;
 
@@ -315,7 +315,7 @@
   // Flash
   // -----
 
-  videojs.FlashMediaSource = videojs.extends(EventTarget, {
+  videojs.FlashMediaSource = videojs.extend(EventTarget, {
     constructor: function(){
       var self = this;
       this.sourceBuffers = [];
@@ -439,7 +439,7 @@
   };
 
   // Source Buffer
-  videojs.FlashSourceBuffer = videojs.extends(EventTarget, {
+  videojs.FlashSourceBuffer = videojs.extend(EventTarget, {
 
     constructor: function(source){
       var encodedHeader;

--- a/test/media-sources_test.js
+++ b/test/media-sources_test.js
@@ -35,7 +35,7 @@
     ok(new videojs.MediaSource({ mode: 'flash' }) instanceof videojs.FlashMediaSource,
        'forced Flash');
     // mock native MediaSources
-    window.MediaSource = videojs.extends(videojs.EventTarget, {});
+    window.MediaSource = videojs.extend(videojs.EventTarget, {});
     ok(new videojs.MediaSource({ mode: 'html5' }) instanceof window.MediaSource,
        'forced HTML5');
 
@@ -51,13 +51,13 @@
   module('HTML MediaSource', {
     setup: function(){
       oldMediaSourceConstructor = window.MediaSource || window.WebKitMediaSource;
-      window.MediaSource = videojs.extends(videojs.EventTarget, {
+      window.MediaSource = videojs.extend(videojs.EventTarget, {
         constructor: function(){
           var sourceBuffers = [];
           this.sourceBuffers = sourceBuffers;
           this.isNative = true;
           this.addSourceBuffer = function(type) {
-            var buffer = new (videojs.extends(videojs.EventTarget, {
+            var buffer = new (videojs.extend(videojs.EventTarget, {
               type: type,
               appendBuffer: function() {}
             }))();

--- a/test/media-sources_test.js
+++ b/test/media-sources_test.js
@@ -443,7 +443,7 @@
 
   module('Flash MediaSource', {
     setup: function(assert) {
-      var swfObj;
+      var swfObj, tech;
       oldMediaSourceConstructor = window.MediaSource || window.WebKitMediaSource;
       window.MediaSource = null;
       window.WebKitMediaSource = null;
@@ -471,8 +471,9 @@
       });
       swfObj = document.createElement('fake-object');
       swfObj.id = 'fake-swf-' + assert.test.testId;
-      player.el().replaceChild(swfObj, player.tech.el());
-      player.tech.el_ = swfObj;
+      player.el().replaceChild(swfObj, player.tech_.el());
+      player.tech_.el_ = swfObj;
+      swfObj.tech = player.tech_;
       swfObj.CallFunction = function(xml) {
         swfCalls.push(xml);
       };
@@ -789,10 +790,10 @@
         data;
 
     // seek to 15 seconds
-    player.tech.seeking = function() {
+    player.tech_.seeking = function() {
       return true;
     };
-    player.tech.currentTime = function() {
+    player.tech_.currentTime = function() {
       return 15;
     };
     // FLV tags for this segment start at 10 seconds in the media
@@ -831,13 +832,13 @@
   test('passes endOfStream network errors to the tech', function() {
     mediaSource.endOfStream('network');
 
-    equal(player.tech.error().code, 2, 'set a network error');
+    equal(player.tech_.error().code, 2, 'set a network error');
   });
 
   test('passes endOfStream network errors to the tech', function() {
     mediaSource.endOfStream('decode');
 
-    equal(player.tech.error().code, 3, 'set a decode error');
+    equal(player.tech_.error().code, 3, 'set a decode error');
   });
 
   module('createObjectURL');


### PR DESCRIPTION
player.tech has been renamed to player.tech_ and made "private". Use a reference on the SWF object instead so we don't break any rules.