### PR TITLE
Add abort

### DIFF
--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -450,6 +450,20 @@ deprecateOldCue = function(cue) {
 
         destinationBuffer.appendBuffer(tempBuffer);
       }
+    },
+    // abort any sourceBuffer actions and throw out any un-appended data
+    abort: function() {
+      if (this.videoBuffer_) {
+        this.videoBuffer_.abort();
+      }
+      if (this.audioBuffer_) {
+        this.audioBuffer_.abort();
+      }
+      if (this.transmuxer_) {
+        this.transmuxer_.postMessage({action: 'resetTransmuxer'});
+      }
+      this.pendingBuffers_.length = 0;
+      this.bufferUpdating_ = false;
     }
   });
 


### PR DESCRIPTION
The MSE-based fake source buffers lacked an abort function which was called by HLS in the resetSrc_ function (called by dispose).