### PR TITLE
Add appendWindowStart to source buffers

### DIFF
--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -304,6 +304,20 @@ addTextTrackData = function (sourceHandler, captionArray, metadataArray) {
           }
         }
       });
+      // setting the append window affects both source buffers
+      Object.defineProperty(this, 'appendWindowStart', {
+        get: function() {
+          return (this.videoBuffer_ || this.audioBuffer_).appendWindowStart;
+        },
+        set: function(start) {
+          if (this.videoBuffer_) {
+            this.videoBuffer_.appendWindowStart = start;
+          }
+          if (this.audioBuffer_) {
+            this.audioBuffer_.appendWindowStart = start;
+          }
+        }
+      });
       // this buffer is "updating" if either of its native buffers are
       Object.defineProperty(this, 'updating', {
         get: function() {


### PR DESCRIPTION
Chrome 45 has issues with appending over previously buffered areas. Expose appendWindowStart so we can avoid overlays for now.