### PR TITLE
Flash fixes

### DIFF
--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -653,7 +653,10 @@ addTextTrackData = function (sourceHandler, captionArray, metadataArray) {
       // MEDIA_ERR_DECODE
       this.tech_.error(3);
     }
-    this.readyState = 'ended';
+    if (this.readyState !== 'ended') {
+      this.readyState = 'ended';
+      this.swfObj.vjs_endOfStream();
+    }
   };
 
   // store references to the media sources so they can be connected
@@ -900,9 +903,6 @@ addTextTrackData = function (sourceHandler, captionArray, metadataArray) {
         this.updating = false;
         this.trigger({ type: 'updateend' });
 
-        if (this.mediaSource.readyState === 'ended') {
-          this.mediaSource.swfObj.vjs_endOfStream();
-        }
       }
     },
 

--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -620,7 +620,7 @@ addTextTrackData = function (sourceHandler, captionArray, metadataArray) {
 
         this.swfObj.vjs_setProperty('duration', value);
 
-        if (value <= oldDuration) {
+        if (value < oldDuration) {
           // In MSE, this triggers the range removal algorithm which causes
           // an update to occur
           for (i = 0; i < this.sourceBuffers.length; i++) {


### PR DESCRIPTION
Some changes to make the Flash MSE polyfill act more like native MSE. 
* `vjs_endOfStream` now called directly from `endOfStream`
* setting a `duration` will call `remove` (which eventually calls 'updateend') if the new duration is less than the old duration
* properly filter tags based on pts since tags are in dts order and the first pts greater or equal to the `targetPts` may not signal the end of filtering 