### PR TITLE
Assign Cue after VTTCue is shimmed

### DIFF
--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -15,8 +15,6 @@
       createTextTracksIfNecessary,
       addTextTrackData;
 
-Cue = window.WebKitDataCue || window.VTTCue;
-
 deprecateOldCue = function(cue) {
   Object.defineProperties(cue.frame, {
     'id': {
@@ -76,10 +74,11 @@ createTextTracksIfNecessary = function (sourceBuffer, mediaSource, segment) {
 };
 
 addTextTrackData = function (sourceHandler, captionArray, metadataArray) {
+  Cue = window.WebKitDataCue || window.VTTCue;
   if (captionArray) {
     captionArray.forEach(function (caption) {
       this.inbandTextTrack_.addCue(
-        new VTTCue(
+        new Cue(
           caption.startTime + this.timestampOffset,
           caption.endTime + this.timestampOffset,
           caption.text


### PR DESCRIPTION
Cue is being defined before vtt.js is inserted into the page with `emulateTextTracks()`. The consequence of this is that Cue creation will fail for browsers that don't have VTTCue natively.

Unit tests wouldn't catch this issue because this project is using video.js and not video.novtt.js with the emulateTextTracks option.