### PR TITLE
Duration fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-contrib-media-sources",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "A Media Source Extensions plugin for video.js",
   "main": "videojs-media-sources.js",
   "scripts": {

--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -160,7 +160,11 @@ addTextTrackData = function (sourceHandler, captionArray, metadataArray) {
       this.duration_ = NaN;
       Object.defineProperty(this, 'duration', {
         get: function() {
-          return self.duration_;
+          if (self.duration_ === Infinity) {
+            return self.duration_;
+          } else {
+            return self.mediaSource_.duration;
+          }
         },
         set: function(duration) {
           var currentDuration;

--- a/test/media-sources_test.js
+++ b/test/media-sources_test.js
@@ -182,6 +182,28 @@
     equal(terminates, 1, 'called terminate on transmux web worker');
   });
 
+
+  test('duration is faked when playing a live stream', function(){
+    var mediaSource = new videojs.MediaSource(),
+        sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+
+    mediaSource.duration = Infinity;
+    mediaSource.mediaSource_.duration = 100;
+
+    equal(mediaSource.mediaSource_.duration, 100, 'native duration was not set to infinity');
+    equal(mediaSource.duration, Infinity, 'the MediaSource wrapper pretends it has an infinite duration');
+  });
+
+  test('duration uses the underlying MediaSource\'s duration when not live', function(){
+    var mediaSource = new videojs.MediaSource(),
+        sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+
+    mediaSource.duration = 100;
+    mediaSource.mediaSource_.duration = 120;
+
+    equal(mediaSource.duration, 120, 'the MediaSource wrapper returns the native duration');
+  });
+
   test('abort on the fake source buffer calls abort on the real ones', function(){
     var mediaSource = new videojs.MediaSource(),
         sourceBuffer = mediaSource.addSourceBuffer('video/mp2t'),


### PR DESCRIPTION
Only use the locally-stored duration value if the mediaSource has a duration of Infinity.