### PR TITLE
Check MediaSources isTypeSupported with the default codec information…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 sudo: false
 node_js:
   - "stable"
+addons:
+  firefox: "latest"
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/src/videojs-media-sources.js
+++ b/src/videojs-media-sources.js
@@ -133,8 +133,11 @@ addTextTrackData = function (sourceHandler, captionArray, metadataArray) {
     return new videojs.FlashMediaSource();
   };
 
+  // Check to see if the native MediaSource object exists and supports
+  // an MP4 container with both H.264 video and AAC-LC audio
   videojs.MediaSource.supportsNativeMediaSources = function() {
-    return !!window.MediaSource;
+    return (!!window.MediaSource &&
+      window.MediaSource.isTypeSupported('video/mp4;codecs="avc1.4d400d,mp4a.40.2"'));
   };
 
   // ----

--- a/test/media-sources_test.js
+++ b/test/media-sources_test.js
@@ -97,12 +97,22 @@
         throw new Error('Testing Mock');
       }
     });
+    window.MediaSource.isTypeSupported = function (mime) {
+      return true;
+    };
+
     ok(new videojs.MediaSource({ mode: 'html5' }) instanceof videojs.HtmlMediaSource,
        'forced HTML5');
 
     // 'auto' should use native MediaSources when they're available
     ok(new videojs.MediaSource() instanceof videojs.HtmlMediaSource,
        'used HTML5');
+    window.MediaSource.isTypeSupported = function (mime) {
+      return false;
+    };
+     // 'auto' should use Flash MediaSources when isTypeSupported is false
+    ok(new videojs.MediaSource() instanceof videojs.FlashMediaSource,
+       'used Flash');
     window.MediaSource = null;
     // 'auto' should use Flash when native MediaSources are not available
     ok(new videojs.MediaSource({ mode: 'flash' }) instanceof videojs.FlashMediaSource,
@@ -127,6 +137,9 @@
           return buffer;
         }
       });
+      window.MediaSource.isTypeSupported = function(mime){
+        return true;
+      };
       window.WebKitMediaSource = window.MediaSource;
     },
     teardown: function(){


### PR DESCRIPTION
… to allow us to fallback to flash when the platform doesn't natively support H.264 or AAC via MSE.

This happens in Chromium which has no native support for mp4 and in both Firefox and IE which use OS provided (but all too often missing) codecs to decode mp4.