### PR TITLE
Support for two VirtualSourceBuffers (audio and video/combined)

### DIFF
--- a/src/html-media-source.js
+++ b/src/html-media-source.js
@@ -134,7 +134,6 @@ export default class HtmlMediaSource extends videojs.EventTarget {
     let mp4aCodec;
     let avcRegEx = /avc1\.[\da-f]+/i;
     let mp4aRegEx = /mp4a\.\d+.\d+/i;
-    let setActiveSourceBuffers;
 
     // create a virtual source buffer to transmux MPEG-2 transport
     // stream segments into fragmented MP4s
@@ -160,14 +159,11 @@ export default class HtmlMediaSource extends videojs.EventTarget {
       buffer = this.mediaSource_.addSourceBuffer(type);
     }
 
-    setActiveSourceBuffers = () => {
-      this.updateActiveSourceBuffers_();
-      // TODO buffer.one causing call stack exceeded exception
-      buffer.off('updateend', setActiveSourceBuffers);
-    };
-    // for combined audio/video tracks, we can only determine if a source buffer is
-    // active after a completed update (once it has/doesn't have videoTracks)
-    buffer.on('updateend', setActiveSourceBuffers);
+    // For combined audio/video tracks, we can only determine if a source buffer is
+    // active after a completed update (once it has/doesn't have videoTracks).
+    // Once https://github.com/videojs/video.js/issues/2981 is resolved, switch to using
+    // buffer.one instead of buffer.on.
+    buffer.on('updateend', this.updateActiveSourceBuffers_.bind(this));
 
     this.sourceBuffers.push(buffer);
     return buffer;

--- a/src/html-media-source.js
+++ b/src/html-media-source.js
@@ -193,6 +193,10 @@ export default class HtmlMediaSource extends videojs.EventTarget {
       // We are using the combined audio/video stream, so only add the combined source
       // buffer.
       this.sourceBuffers.forEach((sourceBuffer) => {
+        /* eslinst-disable */
+        // TODO once codecs are required, we can switch to using the codecs to determine
+        //      what stream is the video stream, rather than relying on videoTracks
+        /* eslinst-enable */
         if (sourceBuffer.videoTracks && sourceBuffer.videoTracks.length > 0) {
           this.activeSourceBuffers_.push(sourceBuffer);
         }

--- a/src/html-media-source.js
+++ b/src/html-media-source.js
@@ -170,12 +170,22 @@ export default class HtmlMediaSource extends videojs.EventTarget {
   }
 
   updateActiveSourceBuffers_() {
+    let altAudioTrackEnabled;
+
+    for (let i = 0; i < this.player_.audioTracks().length; i++) {
+      if (this.player_.audioTracks()[i].enabled &&
+          this.player_.audioTracks()[i].label !== 'main') {
+        altAudioTrackEnabled = true;
+        break;
+      }
+    }
+
     // Retain the reference but empty the array
     this.activeSourceBuffers_.length = 0;
 
-    if (this.player_.audioTracks().some((audioTrack) => audioTrack.enabled)) {
-      // We are using an alternate audio track from the default. Since we currently only
-      // support a max of two source buffers, add all of the source buffers (in order).
+    if (altAudioTrackEnabled) {
+      // Since we currently support a max of two source buffers, add all of the source
+      // buffers (in order).
       this.sourceBuffers.forEach((sourceBuffer) => {
         this.activeSourceBuffers_.push(sourceBuffer);
       });

--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -154,6 +154,12 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
         return videojs.createTimeRanges(ranges);
       }
     });
+
+    Object.defineProperty(this, 'videoTracks', {
+      get() {
+        return this.videoBuffer_.videoTracks;
+      }
+    });
   }
 
   // Transmuxer message handlers

--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -154,12 +154,6 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
         return videojs.createTimeRanges(ranges);
       }
     });
-
-    Object.defineProperty(this, 'videoTracks', {
-      get() {
-        return this.videoBuffer_.videoTracks;
-      }
-    });
   }
 
   // Transmuxer message handlers
@@ -234,6 +228,11 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
         );
       }
     }
+
+    if (this.videoBuffer_) {
+      this.videoTracks = this.videoBuffer_.videoTracks;
+    }
+
     createTextTracksIfNecessary(this, this.mediaSource_, segment);
 
     // Add the segments to the pendingBuffers array

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -673,13 +673,16 @@ QUnit.test('does not wrap mp4 source buffers', function() {
   QUnit.equal(mediaSource.sourceBuffers.length, 2, 'created native buffers');
 });
 
-QUnit.test('can get activeSourceBuffers', () => {
+QUnit.test('can get activeSourceBuffers', function() {
   let mediaSource = new videojs.MediaSource();
 
+  // although activeSourceBuffers should technically be a SourceBufferList, we are
+  // returning it as an array, and users may expect it to behave as such
   QUnit.ok(Array.isArray(mediaSource.activeSourceBuffers));
 });
 
-QUnit.test('active source buffers are updated on each buffer\'s first updateend', () => {
+QUnit.test('active source buffers are updated on each buffer\'s updateend',
+function() {
   let mediaSource = new videojs.MediaSource();
   let updateCallCount = 0;
   let sourceBuffer;
@@ -698,10 +701,6 @@ QUnit.test('active source buffers are updated on each buffer\'s first updateend'
   QUnit.equal(updateCallCount, 1,
               'active source buffers updated after first updateend');
 
-  sourceBuffer.videoBuffer_.trigger('updateend');
-  QUnit.equal(updateCallCount, 1,
-              'active source buffers not updated on second updateend');
-
   sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
   initializeNativeSourceBuffers(sourceBuffer);
 
@@ -711,14 +710,8 @@ QUnit.test('active source buffers are updated on each buffer\'s first updateend'
   sourceBuffer.videoBuffer_.trigger('updateend');
   QUnit.equal(updateCallCount, 2,
               'active source buffers updated after first updateend of new source buffer');
-
-  sourceBuffer.videoBuffer_.trigger('updateend');
-  QUnit.equal(updateCallCount, 2,
-              'active source buffers not updated after second updateend of new source ' +
-              'buffer');
 });
 
-// running under the assumption that we will have a max of two source buffers
 QUnit.test(
 'active source buffers includes all buffers if audio track enabled', function() {
   let mediaSource = new videojs.MediaSource();

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -712,13 +712,17 @@ function() {
               'active source buffers updated after first updateend of new source buffer');
 });
 
-QUnit.test(
-'active source buffers includes all buffers if audio track enabled', function() {
+QUnit.test('active source buffers includes all buffers if alternate audio track enabled',
+function() {
   let mediaSource = new videojs.MediaSource();
   let sourceBufferAudio;
   let sourceBufferCombined;
   let audioTracks = [{
-    enabled: false
+    enabled: true,
+    label: 'main'
+  }, {
+    enabled: false,
+    label: 'English (UK)'
   }];
 
   this.player.audioTracks = () => audioTracks;
@@ -738,7 +742,7 @@ QUnit.test(
   QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
     'active source buffers starts with combined source buffer');
 
-  this.player.audioTracks()[0].enabled = true;
+  this.player.audioTracks()[1].enabled = true;
 
   mediaSource.updateActiveSourceBuffers_();
 

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -17,6 +17,7 @@ QUnit.module('videojs-contrib-media-sources - HTML', {
     this.video = document.createElement('video');
     this.fixture.appendChild(this.video);
     this.player = videojs(this.video);
+    this.player.audioTracks = () => [];
 
     // Mock the environment's timers because certain things - particularly
     // player readiness - are asynchronous in video.js 5.
@@ -154,17 +155,21 @@ QUnit.test('duration is faked when playing a live stream', function() {
 
   mediaSource.duration = Infinity;
   mediaSource.mediaSource_.duration = 100;
-  QUnit.equal(mediaSource.mediaSource_.duration, 100, 'native duration was not set to infinity');
-  QUnit.equal(mediaSource.duration, Infinity, 'the MediaSource wrapper pretends it has an infinite duration');
+  QUnit.equal(mediaSource.mediaSource_.duration, 100,
+              'native duration was not set to infinity');
+  QUnit.equal(mediaSource.duration, Infinity,
+              'the MediaSource wrapper pretends it has an infinite duration');
 });
 
-QUnit.test('duration uses the underlying MediaSource\'s duration when not live', function() {
+QUnit.test(
+'duration uses the underlying MediaSource\'s duration when not live', function() {
   let mediaSource = new videojs.MediaSource();
   let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
 
   mediaSource.duration = 100;
   mediaSource.mediaSource_.duration = 120;
-  QUnit.equal(mediaSource.duration, 120, 'the MediaSource wrapper returns the native duration');
+  QUnit.equal(mediaSource.duration, 120,
+              'the MediaSource wrapper returns the native duration');
 });
 
 QUnit.test('abort on the fake source buffer calls abort on the real ones', function() {
@@ -517,6 +522,8 @@ QUnit.test('aggregates source buffer update events', function() {
   let updateends = 0;
   let updatestarts = 0;
 
+  mediaSource.player_ = this.player;
+
   initializeNativeSourceBuffers(sourceBuffer);
 
   sourceBuffer.addEventListener('updatestart', function() {
@@ -664,4 +671,89 @@ QUnit.test('does not wrap mp4 source buffers', function() {
     'did not need virtual buffers'
   );
   QUnit.equal(mediaSource.sourceBuffers.length, 2, 'created native buffers');
+});
+
+QUnit.test('can get activeSourceBuffers', () => {
+  let mediaSource = new videojs.MediaSource();
+
+  QUnit.ok(Array.isArray(mediaSource.activeSourceBuffers));
+});
+
+QUnit.test('active source buffers are updated on each buffer\'s first updateend', () => {
+  let mediaSource = new videojs.MediaSource();
+  let updateCallCount = 0;
+  let sourceBuffer;
+
+  mediaSource.updateActiveSourceBuffers_ = () => {
+    updateCallCount++;
+  };
+
+  sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+  initializeNativeSourceBuffers(sourceBuffer);
+
+  QUnit.equal(updateCallCount, 0,
+              'active source buffers not updated on adding source buffer');
+
+  sourceBuffer.videoBuffer_.trigger('updateend');
+  QUnit.equal(updateCallCount, 1,
+              'active source buffers updated after first updateend');
+
+  sourceBuffer.videoBuffer_.trigger('updateend');
+  QUnit.equal(updateCallCount, 1,
+              'active source buffers not updated on second updateend');
+
+  sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+  initializeNativeSourceBuffers(sourceBuffer);
+
+  QUnit.equal(updateCallCount, 1,
+              'active source buffers not updated on adding second source buffer');
+
+  sourceBuffer.videoBuffer_.trigger('updateend');
+  QUnit.equal(updateCallCount, 2,
+              'active source buffers updated after first updateend of new source buffer');
+
+  sourceBuffer.videoBuffer_.trigger('updateend');
+  QUnit.equal(updateCallCount, 2,
+              'active source buffers not updated after second updateend of new source ' +
+              'buffer');
+});
+
+// running under the assumption that we will have a max of two source buffers
+QUnit.test(
+'active source buffers includes all buffers if audio track enabled', function() {
+  let mediaSource = new videojs.MediaSource();
+  let sourceBufferAudio;
+  let sourceBufferCombined;
+  let audioTracks = [{
+    enabled: false
+  }];
+
+  this.player.audioTracks = () => audioTracks;
+
+  mediaSource.player_ = this.player;
+
+  sourceBufferAudio = mediaSource.addSourceBuffer('video/m2pt');
+  sourceBufferCombined = mediaSource.addSourceBuffer('video/m2pt');
+  sourceBufferCombined.videoTracks = {
+    length: 1
+  };
+
+  mediaSource.updateActiveSourceBuffers_();
+
+  QUnit.equal(mediaSource.activeSourceBuffers.length, 1,
+    'active source buffers starts with one source buffer');
+  QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
+    'active source buffers starts with combined source buffer');
+
+  this.player.audioTracks()[0].enabled = true;
+
+  mediaSource.updateActiveSourceBuffers_();
+
+  QUnit.equal(mediaSource.activeSourceBuffers.length, 2,
+    'active source buffers includes both source buffers');
+  // maintains same order as source buffers were created
+  QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferAudio,
+    'active source buffers starts with audio source buffer');
+  QUnit.equal(mediaSource.activeSourceBuffers[1], sourceBufferCombined,
+    'active source buffers ends with combined source buffer');
 });


### PR DESCRIPTION
This add support for two VirtualSourceBuffers, one audio only, and one either video only or video and audio combined.

This is a working PR, and is proposed for general comments/critique. It has not been tested thoroughly, as full testing is pending the Video.js audioTracks API.

Note that there is a TODO within the code to switch an event listener from on to one. In running tests, the one listener was hitting the max stack limit, and needs further debugging to discover where the recursion is occurring.

edit: removed "not ready" at beginning