### PR TITLE
Fix/add unit tests and cleanup some of the logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
     "test/"
   ],
   "dependencies": {
-    "video.js": "^5.0.0",
     "mux.js": "^2.0.0",
+    "video.js": "^5.9.0-1",
     "webworkify": "1.0.2"
   },
   "devDependencies": {
@@ -104,7 +104,7 @@
     "qunitjs": "^1.0.0",
     "serve-static": "^1.10.0",
     "shelljs": "^0.5.3",
-    "sinon": "^1.0.0",
+    "sinon": "1.14.1",
     "uglify-js": "^2.5.0",
     "videojs-standard": "^4.0.0",
     "watchify": "^3.6.0"

--- a/src/codec-utils.js
+++ b/src/codec-utils.js
@@ -1,0 +1,33 @@
+const isAudioCodec = function(codec) {
+  return (/mp4a\.\d+.\d+/i).test(codec);
+};
+
+const isVideoCodec = function(codec) {
+  return (/avc1\.[\da-f]+/i).test(codec);
+};
+
+const parseContentType = function(type) {
+  let object = {type: '', parameters: {}};
+  let parameters = type.trim().split(';');
+
+  // first parameter should always be content-type
+  object.type = parameters.shift().trim();
+  parameters.forEach((parameter) => {
+    let pair = parameter.trim().split('=');
+
+    if (pair.length > 1) {
+      let name = pair[0].replace(/"/g, '').trim();
+      let value = pair[1].replace(/"/g, '').trim();
+
+      object.parameters[name] = value;
+    }
+  });
+
+  return object;
+};
+
+export default {
+  isAudioCodec,
+  parseContentType,
+  isVideoCodec
+};

--- a/src/flash-media-source.js
+++ b/src/flash-media-source.js
@@ -1,6 +1,7 @@
 import videojs from 'video.js';
 import FlashSourceBuffer from './flash-source-buffer';
 import FlashConstants from './flash-constants';
+import {parseContentType} from './codec-utils';
 
 export default class FlashMediaSource extends videojs.EventTarget {
   constructor() {
@@ -36,10 +37,11 @@ export default class FlashMediaSource extends videojs.EventTarget {
 
   // create a new source buffer to receive a type of media data
   addSourceBuffer(type) {
+    let parsedType = parseContentType(type);
     let sourceBuffer;
 
     // if this is an FLV type, we'll push data to flash
-    if (type.indexOf('video/mp2t') === 0) {
+    if (parsedType.type === 'video/mp2t') {
       // Flash source buffers
       sourceBuffer = new FlashSourceBuffer(this);
     } else {


### PR DESCRIPTION
support for audio/video only and combined streams (if we have a codec)
fix a bug where we would not remove audioBuffer if audio was disabled
updated all mine/content type and codec code to use codec-utils
linted all of the code for everything except TODO
reworked tests to fit with new buffer changes
added tests for codecs, audio only, and video only
improved realsourcebuffer creation logic