### PR TITLE
Add isTypeSupported method existing checker

### DIFF
--- a/src/videojs-contrib-media-sources.js
+++ b/src/videojs-contrib-media-sources.js
@@ -36,7 +36,7 @@ const open = function(msObjectURL, swfId) {
 // Check to see if the native MediaSource object exists and supports
 // an MP4 container with both H.264 video and AAC-LC audio
 const supportsNativeMediaSources = function() {
-  return (!!window.MediaSource &&
+  return (!!window.MediaSource && !!window.MediaSource.isTypeSupported &&
     window.MediaSource.isTypeSupported('video/mp4;codecs="avc1.4d400d,mp4a.40.2"'));
 };
 


### PR DESCRIPTION
 if MediaSource object exists but isTypeSupported method doesn't exist, script and videoJS will be broken.

This issue can be reproduced in Opera TV OS or Philips Android TV which uses Opera as built-in HTML5 application browser.