### PR TITLE
Fix updateactive

### DIFF
--- a/src/html-media-source.js
+++ b/src/html-media-source.js
@@ -79,21 +79,21 @@ export default class HtmlMediaSource extends videojs.EventTarget {
       // Retain the reference but empty the array
       this.activeSourceBuffers_.length = 0;
 
-      // By default, disable the audio in the combined virtual source buffer
-      // and enable the audio-only source buffer.
-      let combined = true;
-      let audioOnly = false;
+      // By default, the audio in the combined virtual source buffer is enabled
+      // and the audio-only source buffer (if it exists) is disabled.
+      let combined = false;
+      let audioOnly = true;
 
       // TODO: maybe we can store the sourcebuffers on the track objects?
       // safari may do something like this
       for (let i = 0; i < this.player_.audioTracks().length; i++) {
         let track = this.player_.audioTracks()[i];
 
-        if (track.enabled && track.kind === 'main') {
-          // The enabled track is a combined audio and video track so we'll enable the
-          // combined source buffer and disable the audio-only source buffer.
-          combined = false;
-          audioOnly = true;
+        if (track.enabled && track.kind !== 'main') {
+          // The enabled track is an alternate audio track so disable the audio in
+          // the combined source buffer and enable the audio-only source buffer.
+          combined = true;
+          audioOnly = false;
           break;
         }
       }

--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -90,9 +90,9 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
     // this buffer is "updating" if either of its native buffers are
     Object.defineProperty(this, 'updating', {
       get() {
-        return this.bufferUpdating_ ||
+        return !!(this.bufferUpdating_ ||
           (!this.audioDisabled_ && this.audioBuffer_ && this.audioBuffer_.updating) ||
-          (this.videoBuffer_ && this.videoBuffer_.updating);
+          (this.videoBuffer_ && this.videoBuffer_.updating));
       }
     });
 


### PR DESCRIPTION
Repair the completely broken logic that resulted from replacing enableAudio and disableAudio functions on VirtualSourceBuffers with a boolean property. The tests were passing completely by accident even though the logic was inverted in two cases.

Also includes a tiny fix that forces `VirtualSourceBuffer#updating` to always return a boolean instead of sometimes returning `undefined`.