### PR TITLE
Adding support for video and audio only playlists

### DIFF
--- a/src/html-media-source.js
+++ b/src/html-media-source.js
@@ -37,12 +37,12 @@ export default class HtmlMediaSource extends videojs.EventTarget {
     super();
     let property;
 
-    this.mediaSource_ = new window.MediaSource();
+    this.nativeMediaSource_ = new window.MediaSource();
     // delegate to the native MediaSource's methods by default
-    for (property in this.mediaSource_) {
+    for (property in this.nativeMediaSource_) {
       if (!(property in HtmlMediaSource.prototype) &&
-          typeof this.mediaSource_[property] === 'function') {
-        this[property] = this.mediaSource_[property].bind(this.mediaSource_);
+          typeof this.nativeMediaSource_[property] === 'function') {
+        this[property] = this.nativeMediaSource_[property].bind(this.nativeMediaSource_);
       }
     }
 
@@ -55,12 +55,12 @@ export default class HtmlMediaSource extends videojs.EventTarget {
         if (this.duration_ === Infinity) {
           return this.duration_;
         }
-        return this.mediaSource_.duration;
+        return this.nativeMediaSource_.duration;
       },
       set(duration) {
         this.duration_ = duration;
         if (duration !== Infinity) {
-          this.mediaSource_.duration = duration;
+          this.nativeMediaSource_.duration = duration;
           return;
         }
       }
@@ -68,15 +68,15 @@ export default class HtmlMediaSource extends videojs.EventTarget {
     Object.defineProperty(this, 'seekable', {
       get() {
         if (this.duration_ === Infinity) {
-          return videojs.createTimeRanges([[0, this.mediaSource_.duration]]);
+          return videojs.createTimeRanges([[0, this.nativeMediaSource_.duration]]);
         }
-        return this.mediaSource_.seekable;
+        return this.nativeMediaSource_.seekable;
       }
     });
 
     Object.defineProperty(this, 'readyState', {
       get() {
-        return this.mediaSource_.readyState;
+        return this.nativeMediaSource_.readyState;
       }
     });
 
@@ -156,7 +156,7 @@ export default class HtmlMediaSource extends videojs.EventTarget {
       'sourceclose',
       'sourceended'
     ].forEach(function(eventName) {
-      this.mediaSource_.addEventListener(eventName, this.trigger.bind(this));
+      this.nativeMediaSource_.addEventListener(eventName, this.trigger.bind(this));
     }, this);
 
     // capture the associated player when the MediaSource is
@@ -214,9 +214,9 @@ export default class HtmlMediaSource extends videojs.EventTarget {
       throw error;
     }
 
-    if (end > this.mediaSource_.duration ||
-        isNaN(this.mediaSource_.duration)) {
-      this.mediaSource_.duration = end;
+    if (end > this.nativeMediaSource_.duration ||
+        isNaN(this.nativeMediaSource_.duration)) {
+      this.nativeMediaSource_.duration = end;
     }
   }
 
@@ -264,7 +264,7 @@ export default class HtmlMediaSource extends videojs.EventTarget {
       buffer = new VirtualSourceBuffer(this, codecs);
     } else {
       // delegate to the native implementation
-      buffer = this.mediaSource_.addSourceBuffer(type);
+      buffer = this.nativeMediaSource_.addSourceBuffer(type);
     }
 
     this.sourceBuffers.push(buffer);

--- a/src/videojs-contrib-media-sources.js
+++ b/src/videojs-contrib-media-sources.js
@@ -105,7 +105,7 @@ export const URL = {
 
     // use the native MediaSource to generate an object URL
     if (object instanceof HtmlMediaSource) {
-      url = window.URL.createObjectURL(object.mediaSource_);
+      url = window.URL.createObjectURL(object.nativeMediaSource_);
       object.url_ = url;
       return url;
     }

--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -396,12 +396,14 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
       return segmentObj;
     }, sortedSegments);
 
-    // Create the real source buffers if they don't exist by now
+    // Create the real source buffers if they don't exist by now since we
+    // finally are sure what tracks are contained in the source
     if (!this.videoBuffer_ && !this.audioBuffer_) {
+      // Remove any codecs that may have been specified by default but
+      // are no longer applicable now
       if (sortedSegments.video.bytes === 0) {
         this.videoCodec_ = null;
       }
-
       if (sortedSegments.audio.bytes === 0) {
         this.audioCodec_ = null;
       }

--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -29,7 +29,6 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
     this.pendingBuffers_ = [];
     this.bufferUpdating_ = false;
     this.mediaSource_ = mediaSource;
-    this.nativeMediaSource = this.mediaSource_.mediaSource_;
     this.codecs_ = codecs;
     this.audioCodec_ = null;
     this.videoCodec_ = null;
@@ -259,7 +258,7 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
       if (this.mediaSource_[`${type}Buffer_`]) {
         buffer = this.mediaSource_[`${type}Buffer_`];
       } else {
-        buffer = this.nativeMediaSource.addSourceBuffer(
+        buffer = this.mediaSource_.nativeMediaSource_.addSourceBuffer(
           type + '/mp4;codecs="' + this[`${type}Codec_`] + '"'
         );
         this.mediaSource_[`${type}Buffer_`] = buffer;

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -1023,7 +1023,7 @@ QUnit.test('audio segments with info trigger audioinfo event', function() {
 });
 
 QUnit.test('creates native SourceBuffers immediately if a second ' +
-  'VirtualSourceBuffer is created', function() {
+           'VirtualSourceBuffer is created', function() {
   let mediaSource = new videojs.MediaSource();
   let sourceBuffer =
     mediaSource.addSourceBuffer('video/mp2t; codecs="avc1.64001f,mp4a.40.5"');


### PR DESCRIPTION
Defer the creation of the underlying real SourceBuffers until one of two conditions is fulfilled:
1. We get data back from the transmuxer so that we know the track layout of the source.
2. a second VirtualSourceBuffer is created meaning that both video and audio source buffers are necessary.