### PR TITLE
Fixed a bug where we weren't forcing the creation of real sourcebuffers on the second virtual sourcebuffer

### DIFF
--- a/src/html-media-source.js
+++ b/src/html-media-source.js
@@ -234,19 +234,6 @@ export default class HtmlMediaSource extends videojs.EventTarget {
     // Create a VirtualSourceBuffer to transmux MPEG-2 transport
     // stream segments into fragmented MP4s
     if (parsedType.type === 'video/mp2t') {
-      if (this.sourceBuffers.length !== 0) {
-        // If another VirtualSourceBuffer already exists, then we are creating a
-        // SourceBuffer for an alternate audio track and therefore we know that
-        // the source has both an audio and video track.
-        // That means we should trigger the manual creation of the real
-        // SourceBuffers instead of waiting for the transmuxer to return data
-        this.sourceBuffers[0].createRealSourceBuffers_();
-
-        // Automatically disable the audio on the first source buffer if
-        // a second source buffer is ever created
-        this.sourceBuffers[0].audioDisabled_ = true;
-      }
-
       let codecs = [];
 
       if (parsedType.parameters && parsedType.parameters.codecs) {
@@ -262,6 +249,20 @@ export default class HtmlMediaSource extends videojs.EventTarget {
       }
 
       buffer = new VirtualSourceBuffer(this, codecs);
+
+      if (this.sourceBuffers.length !== 0) {
+        // If another VirtualSourceBuffer already exists, then we are creating a
+        // SourceBuffer for an alternate audio track and therefore we know that
+        // the source has both an audio and video track.
+        // That means we should trigger the manual creation of the real
+        // SourceBuffers instead of waiting for the transmuxer to return data
+        this.sourceBuffers[0].createRealSourceBuffers_();
+        buffer.createRealSourceBuffers_();
+
+        // Automatically disable the audio on the first source buffer if
+        // a second source buffer is ever created
+        this.sourceBuffers[0].audioDisabled_ = true;
+      }
     } else {
       // delegate to the native implementation
       buffer = this.nativeMediaSource_.addSourceBuffer(type);

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -1056,4 +1056,7 @@ QUnit.test('creates native SourceBuffers immediately if a second ' +
     sourceBuffer.audioDisabled_,
     true,
     'first source buffer\'s audio is automatically disabled');
+  QUnit.ok(
+    sourceBuffer2.audioBuffer_,
+    'second source buffer has an audio source buffer');
 });


### PR DESCRIPTION
Fixing a bug with #85 where we were creating the real SourceBuffers for the first VirtualSourceBuffer but still deferring the creation or assignment of the second VirtualSourceBuffer's real source buffers until after it received data back from the transmuxer.

This was causing a problem when switching between multiple audio tracks because we weren't able to clear the real source buffer to allow us to switch tracks immediately.