### PR TITLE
Set the linter to a specific version

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "shelljs": "^0.5.3",
     "sinon": "1.14.1",
     "uglify-js": "^2.5.0",
-    "videojs-standard": "^4.0.0",
+    "videojs-standard": "4.0.2",
     "watchify": "^3.6.0"
   }
 }


### PR DESCRIPTION
This is to avoid breaking the build if there is a subtle breaking rule change.