### PR TITLE
updating the metadata cues

### DIFF
--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -63,22 +63,42 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
     }, sourceHandler);
   }
 
+
   if (metadataArray) {
+
+
     metadataArray.forEach(function(metadata) {
       let time = metadata.cueTime + this.timestampOffset;
+      let videoDuration = Number.isFinite(this.mediaSource_.duration) ?
+        this.mediaSource_.duration :
+        Number.MAX_VALUE;
 
       metadata.frames.forEach(function(frame) {
         let cue = new Cue(
-            time,
-            time,
-            frame.value || frame.url || frame.data || '');
+          time,
+          videoDuration,
+          frame.value || frame.url || frame.data || '');
 
         cue.frame = frame;
         cue.value = frame;
         deprecateOldCue(cue);
+
         this.metadataTrack_.addCue(cue);
       }, this);
     }, sourceHandler);
+
+    /** Updating the metadeta cues so that
+     * the endTime of each cue is the startTime of the next cue
+     * the endTime of last cue is the duration of the video
+     */
+    if (sourceHandler.metadataTrack_ && sourceHandler.metadataTrack_.cues) {
+      for (let i = 0; i < sourceHandler.metadataTrack_.cues.length - 1; i++) {
+
+        if (sourceHandler.metadataTrack_.cues[i].endTime != sourceHandler.metadataTrack_.cues[i + 1].startTime) {
+          sourceHandler.metadataTrack_.cues[i].endTime = sourceHandler.metadataTrack_.cues[i + 1].startTime;
+        }
+      }
+    }
   }
 };
 

--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -96,20 +96,19 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
      * the endTime of last cue is the duration of the video
      */
     if (sourceHandler.metadataTrack_ && sourceHandler.metadataTrack_.cues) {
-      for (let i = 0; i <= sourceHandler.metadataTrack_.cues.length - 1; i++) {
-        if (i === sourceHandler.metadataTrack_.cues.length - 1) {
-          sourceHandler.metadataTrack_.cues[i].endTime = videoDuration;
+      let cues = sourceHandler.metadataTrack_.cues;
+
+      for (let i = 0; i <= cues.length - 1; i++) {
+        if (i === cues.length - 1) {
+          cues[i].endTime = videoDuration;
         } else {
-          sourceHandler.metadataTrack_.cues[i].endTime =
-          sourceHandler.metadataTrack_.cues[i + 1].startTime;
+          cues[i].endTime = cues[i + 1].startTime;
         }
       }
+      sourceHandler.mediaSource_.on('sourceended', (event) => {
+        cues[cues.length - 1].endTime = videoDuration;
+      });
     }
-    sourceHandler.mediaSource_.on('sourceended', (event) => {
-      let numberOfCues = sourceHandler.metadataTrack_.cues.length;
-
-      sourceHandler.metadataTrack_.cues[numberOfCues - 1].endTime = videoDuration;
-    });
   }
 };
 

--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -116,4 +116,7 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
   }
 };
 
-export default addTextTrackData;
+export default {
+  addTextTrackData,
+  durationOfVideo
+};

--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -98,13 +98,11 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
     if (sourceHandler.metadataTrack_ && sourceHandler.metadataTrack_.cues) {
       let cues = sourceHandler.metadataTrack_.cues;
 
-      for (let i = 0; i <= cues.length - 1; i++) {
-        if (i === cues.length - 1) {
-          cues[i].endTime = videoDuration;
-        } else {
-          cues[i].endTime = cues[i + 1].startTime;
-        }
+      for (let i = 0; i < cues.length - 1; i++) {
+        cues[i].endTime = cues[i + 1].startTime;
       }
+      cues[cues.length - 1].endTime = videoDuration;
+
       sourceHandler.mediaSource_.on('sourceended', (event) => {
         cues[cues.length - 1].endTime = videoDuration;
       });

--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -66,13 +66,12 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
   if (metadataArray) {
     let videoDuration;
 
-    if(isNaN(sourceHandler.mediaSource_.duration) || 
-      sourceHandler.mediaSource_.duration === Infinity || 
+    if (isNaN(sourceHandler.mediaSource_.duration) ||
+      sourceHandler.mediaSource_.duration === Infinity ||
       sourceHandler.mediaSource_.duration === -Infinity) {
       videoDuration = Number.MAX_VALUE;
-    }
-    else {
-      videoDuration = Math.min(sourceHandler.mediaSource_.duration, Number.MAX_VALUE);
+    } else {
+      videoDuration = sourceHandler.mediaSource_.duration;
     }
 
     metadataArray.forEach(function(metadata) {

--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -67,8 +67,7 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
     let videoDuration;
 
     if (isNaN(sourceHandler.mediaSource_.duration) ||
-      sourceHandler.mediaSource_.duration === Infinity ||
-      sourceHandler.mediaSource_.duration === -Infinity) {
+       Math.abs(sourceHandler.mediaSource_.duration) === Infinity) {
       videoDuration = Number.MAX_VALUE;
     } else {
       videoDuration = sourceHandler.mediaSource_.duration;

--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -64,6 +64,8 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
   }
 
   if (metadataArray) {
+    let videoDuration = Math.min(sourceHandler.mediaSource_.duration, Number.MAX_VALUE);
+
     metadataArray.forEach(function(metadata) {
       let time = metadata.cueTime + this.timestampOffset;
       let endTimeCue = 0;
@@ -87,17 +89,21 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
      * the endTime of last cue is the duration of the video
      */
     if (sourceHandler.metadataTrack_ && sourceHandler.metadataTrack_.cues) {
-      for (let i = 0; i < sourceHandler.metadataTrack_.cues.length - 1; i++) {
-        if (sourceHandler.metadataTrack_.cues[i].endTime !==
-          sourceHandler.metadataTrack_.cues[i + 1].startTime) {
+      for (let i = 0; i <= sourceHandler.metadataTrack_.cues.length - 1; i++) {
+        if (i === sourceHandler.metadataTrack_.cues.length - 1) {
+          sourceHandler.metadataTrack_.cues[i].endTime = videoDuration;
+        } else if (sourceHandler.metadataTrack_.cues[i].endTime !==
+          sourceHandler.metadataTrack_.cues[i + 1].startTime &&
+          i < sourceHandler.metadataTrack_.cues.length - 1) {
           sourceHandler.metadataTrack_.cues[i].endTime =
             sourceHandler.metadataTrack_.cues[i + 1].startTime;
         }
       }
     }
     sourceHandler.mediaSource_.on('sourceended', (event) => {
-      let videoDuration = Math.min(sourceHandler.mediaSource_.duration, Number.MAX_VALUE);
-      sourceHandler.metadataTrack_.cues[sourceHandler.metadataTrack_.cues.length - 1].endTime = videoDuration;
+      let numberOfCues = sourceHandler.metadataTrack_.cues.length;
+
+      sourceHandler.metadataTrack_.cues[numberOfCues - 1].endTime = videoDuration;
     });
   }
 };

--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -104,9 +104,8 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
       for (let j = 0; j < cues.length; j++) {
         cuesArray.push(cues[j]);
       }
-      cuesArray.sort(function(first, second) {
-        return first.startTime - second.startTime;
-      });
+      cuesArray.sort((first, second) => first.startTime - second.startTime);
+
       for (let i = 0; i < cuesArray.length - 1; i++) {
         if (cuesArray[i].endTime !== cuesArray[i + 1].startTime) {
           cuesArray[i].endTime = cuesArray[i + 1].startTime;

--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -63,10 +63,7 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
     }, sourceHandler);
   }
 
-
   if (metadataArray) {
-
-
     metadataArray.forEach(function(metadata) {
       let time = metadata.cueTime + this.timestampOffset;
       let videoDuration = Number.isFinite(this.mediaSource_.duration) ?
@@ -94,8 +91,10 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
     if (sourceHandler.metadataTrack_ && sourceHandler.metadataTrack_.cues) {
       for (let i = 0; i < sourceHandler.metadataTrack_.cues.length - 1; i++) {
 
-        if (sourceHandler.metadataTrack_.cues[i].endTime != sourceHandler.metadataTrack_.cues[i + 1].startTime) {
-          sourceHandler.metadataTrack_.cues[i].endTime = sourceHandler.metadataTrack_.cues[i + 1].startTime;
+        if (sourceHandler.metadataTrack_.cues[i].endTime !==
+          sourceHandler.metadataTrack_.cues[i + 1].startTime) {
+          sourceHandler.metadataTrack_.cues[i].endTime =
+            sourceHandler.metadataTrack_.cues[i + 1].startTime;
         }
       }
     }

--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -68,12 +68,11 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
 
     metadataArray.forEach(function(metadata) {
       let time = metadata.cueTime + this.timestampOffset;
-      let endTimeCue = 0;
 
       metadata.frames.forEach(function(frame) {
         let cue = new Cue(
           time,
-          endTimeCue,
+          time,
           frame.value || frame.url || frame.data || '');
 
         cue.frame = frame;

--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -99,11 +99,9 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
       for (let i = 0; i <= sourceHandler.metadataTrack_.cues.length - 1; i++) {
         if (i === sourceHandler.metadataTrack_.cues.length - 1) {
           sourceHandler.metadataTrack_.cues[i].endTime = videoDuration;
-        } else if (sourceHandler.metadataTrack_.cues[i].endTime !==
-          sourceHandler.metadataTrack_.cues[i + 1].startTime &&
-          i < sourceHandler.metadataTrack_.cues.length - 1) {
+        } else {
           sourceHandler.metadataTrack_.cues[i].endTime =
-            sourceHandler.metadataTrack_.cues[i + 1].startTime;
+          sourceHandler.metadataTrack_.cues[i + 1].startTime;
         }
       }
     }

--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -66,14 +66,12 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
   if (metadataArray) {
     metadataArray.forEach(function(metadata) {
       let time = metadata.cueTime + this.timestampOffset;
-      let videoDuration = Number.isFinite(this.mediaSource_.duration) ?
-        this.mediaSource_.duration :
-        Number.MAX_VALUE;
+      let endTimeCue = 0;
 
       metadata.frames.forEach(function(frame) {
         let cue = new Cue(
           time,
-          videoDuration,
+          endTimeCue,
           frame.value || frame.url || frame.data || '');
 
         cue.frame = frame;
@@ -90,7 +88,6 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
      */
     if (sourceHandler.metadataTrack_ && sourceHandler.metadataTrack_.cues) {
       for (let i = 0; i < sourceHandler.metadataTrack_.cues.length - 1; i++) {
-
         if (sourceHandler.metadataTrack_.cues[i].endTime !==
           sourceHandler.metadataTrack_.cues[i + 1].startTime) {
           sourceHandler.metadataTrack_.cues[i].endTime =
@@ -98,6 +95,10 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
         }
       }
     }
+    sourceHandler.mediaSource_.on('sourceended', (event) => {
+      let videoDuration = Math.min(sourceHandler.mediaSource_.duration, Number.MAX_VALUE);
+      sourceHandler.metadataTrack_.cues[sourceHandler.metadataTrack_.cues.length - 1].endTime = videoDuration;
+    });
   }
 };
 

--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -64,7 +64,16 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
   }
 
   if (metadataArray) {
-    let videoDuration = Math.min(sourceHandler.mediaSource_.duration, Number.MAX_VALUE);
+    let videoDuration;
+
+    if(isNaN(sourceHandler.mediaSource_.duration) || 
+      sourceHandler.mediaSource_.duration === Infinity || 
+      sourceHandler.mediaSource_.duration === -Infinity) {
+      videoDuration = Number.MAX_VALUE;
+    }
+    else {
+      videoDuration = Math.min(sourceHandler.mediaSource_.duration, Number.MAX_VALUE);
+    }
 
     metadataArray.forEach(function(metadata) {
       let time = metadata.cueTime + this.timestampOffset;

--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -6,7 +6,7 @@ import videojs from 'video.js';
 import flv from 'mux.js/lib/flv';
 import removeCuesFromTrack from './remove-cues-from-track';
 import createTextTracksIfNecessary from './create-text-tracks-if-necessary';
-import addTextTrackData from './add-text-track-data';
+import {addTextTrackData} from './add-text-track-data';
 import FlashConstants from './flash-constants';
 
 /**

--- a/src/html-media-source.js
+++ b/src/html-media-source.js
@@ -180,6 +180,24 @@ export default class HtmlMediaSource extends videojs.EventTarget {
       }
     });
 
+    this.on('sourceended', (event) => {
+      let duration = this.duration;
+
+      for (let i = 0; i < this.sourceBuffers.length; i++) {
+        let sourcebuffer = this.sourceBuffers[i];
+        let cues = sourcebuffer.metadataTrack_.cues;
+
+        if (cues) {
+          if (isNaN(duration) || Math.abs(duration) === Infinity) {
+            duration = Number.MAX_VALUE;
+          } else {
+            duration = this.duration;
+          }
+          cues[cues.length - 1].endTime = duration;
+        }
+      }
+    });
+
     // explicitly terminate any WebWorkers that were created
     // by SourceHandlers
     this.on('sourceclose', function(event) {

--- a/src/html-media-source.js
+++ b/src/html-media-source.js
@@ -5,6 +5,7 @@ import window from 'global/window';
 import document from 'global/document';
 import videojs from 'video.js';
 import VirtualSourceBuffer from './virtual-source-buffer';
+import {durationOfVideo} from './add-text-track-data';
 import {isAudioCodec, isVideoCodec, parseContentType} from './codec-utils';
 
 /**
@@ -181,18 +182,13 @@ export default class HtmlMediaSource extends videojs.EventTarget {
     });
 
     this.on('sourceended', (event) => {
-      let duration = this.duration;
+      let duration = durationOfVideo(this.duration);
 
       for (let i = 0; i < this.sourceBuffers.length; i++) {
         let sourcebuffer = this.sourceBuffers[i];
         let cues = sourcebuffer.metadataTrack_.cues;
 
         if (cues) {
-          if (isNaN(duration) || Math.abs(duration) === Infinity) {
-            duration = Number.MAX_VALUE;
-          } else {
-            duration = this.duration;
-          }
           cues[cues.length - 1].endTime = duration;
         }
       }

--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -4,7 +4,7 @@
 import videojs from 'video.js';
 import createTextTracksIfNecessary from './create-text-tracks-if-necessary';
 import removeCuesFromTrack from './remove-cues-from-track';
-import addTextTrackData from './add-text-track-data';
+import {addTextTrackData} from './add-text-track-data';
 import work from 'webworkify';
 import transmuxWorker from './transmuxer-worker';
 import {isAudioCodec, isVideoCodec} from './codec-utils';

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -742,6 +742,9 @@ QUnit.test('translates caption events into WebVTT cues', function() {
 QUnit.test('translates metadata events into WebVTT cues', function() {
   let mediaSource = new videojs.MediaSource();
   let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+  mediaSource.duration = 50;
+  mediaSource.nativeMediaSource_.duration = 60;
+
   let types = [];
   let metadata = [{
     cueTime: 2,
@@ -782,7 +785,7 @@ QUnit.test('translates metadata events into WebVTT cues', function() {
   'in-band metadata track dispatch type correctly set'
   );
   let cues = sourceBuffer.metadataTrack_.cues;
-
+  
   QUnit.equal(types.length, 1, 'created one text track');
   QUnit.equal(types[0], 'metadata', 'the type was metadata');
   QUnit.equal(cues.length, 3, 'created three cues');
@@ -792,9 +795,11 @@ QUnit.test('translates metadata events into WebVTT cues', function() {
   QUnit.equal(cues[1].text, 'This is a text tag', 'included the text');
   QUnit.equal(cues[1].startTime, 12, 'started at twelve');
   QUnit.equal(cues[1].endTime, 22, 'ended at the startTime of next cue(22)');
+  mediaSource.trigger('sourceended');
   QUnit.equal(cues[2].text, 'This is a priv tag', 'included the text');
   QUnit.equal(cues[2].startTime, 22, 'started at twenty two');
-  QUnit.equal(cues[2].endTime, Number.MAX_VALUE, 'ended at duration of the video');
+  QUnit.equal(cues[2].endTime, mediaSource.duration,
+   'sourceended is fired');
 });
 
 QUnit.test('does not wrap mp4 source buffers', function() {

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -743,7 +743,6 @@ QUnit.test('translates metadata events into WebVTT cues', function() {
   let mediaSource = new videojs.MediaSource();
   let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
   let types = [];
-  let cues = [];
   let metadata = [{
     cueTime: 2,
     frames: [{
@@ -763,8 +762,9 @@ QUnit.test('translates metadata events into WebVTT cues', function() {
     addTextTrack(type) {
       types.push(type);
       return {
+        cues: [],
         addCue(cue) {
-          cues.push(cue);
+          this.cues.push(cue);
         }
       };
     }
@@ -781,18 +781,20 @@ QUnit.test('translates metadata events into WebVTT cues', function() {
     16,
   'in-band metadata track dispatch type correctly set'
   );
+  let cues = sourceBuffer.metadataTrack_.cues;
+
   QUnit.equal(types.length, 1, 'created one text track');
   QUnit.equal(types[0], 'metadata', 'the type was metadata');
   QUnit.equal(cues.length, 3, 'created three cues');
   QUnit.equal(cues[0].text, 'This is a url tag', 'included the text');
   QUnit.equal(cues[0].startTime, 12, 'started at twelve');
-  QUnit.equal(cues[0].endTime, 12, 'ended at twelve');
+  QUnit.equal(cues[0].endTime, 12, 'ended at StartTime of next cue(12)');
   QUnit.equal(cues[1].text, 'This is a text tag', 'included the text');
   QUnit.equal(cues[1].startTime, 12, 'started at twelve');
-  QUnit.equal(cues[1].endTime, 12, 'ended at twelve');
+  QUnit.equal(cues[1].endTime, 22, 'ended at the startTime of next cue(22)');
   QUnit.equal(cues[2].text, 'This is a priv tag', 'included the text');
   QUnit.equal(cues[2].startTime, 22, 'started at twenty two');
-  QUnit.equal(cues[2].endTime, 22, 'ended at twenty two');
+  QUnit.equal(cues[2].endTime, Number.MAX_VALUE, 'ended at duration of the video');
 });
 
 QUnit.test('does not wrap mp4 source buffers', function() {

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -743,7 +743,7 @@ QUnit.test('translates metadata events into WebVTT cues', function() {
   let mediaSource = new videojs.MediaSource();
   let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
 
-  mediaSource.duration = 50;
+  mediaSource.duration = Infinity;
   mediaSource.nativeMediaSource_.duration = 60;
 
   let types = [];
@@ -796,11 +796,12 @@ QUnit.test('translates metadata events into WebVTT cues', function() {
   QUnit.equal(cues[1].text, 'This is a text tag', 'included the text');
   QUnit.equal(cues[1].startTime, 12, 'started at twelve');
   QUnit.equal(cues[1].endTime, 22, 'ended at the startTime of next cue(22)');
-  mediaSource.trigger('sourceended');
   QUnit.equal(cues[2].text, 'This is a priv tag', 'included the text');
   QUnit.equal(cues[2].startTime, 22, 'started at twenty two');
-  QUnit.equal(cues[2].endTime, mediaSource.duration,
-   'sourceended is fired');
+  QUnit.equal(cues[2].endTime, Number.MAX_VALUE, 'ended at the maximum value');
+  mediaSource.duration = 100;
+  mediaSource.trigger('sourceended');
+  QUnit.equal(cues[2].endTime, mediaSource.duration, 'sourceended is fired');
 });
 
 QUnit.test('does not wrap mp4 source buffers', function() {

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -8,7 +8,10 @@ import HtmlMediaSource from '../src/html-media-source';
 // we disable this because browserify needs to include these files
 // but the exports are not important
 /* eslint-disable no-unused-vars */
-import {MediaSource, URL} from '../src/videojs-contrib-media-sources.js';
+import {
+  MediaSource,
+  URL
+} from '../src/videojs-contrib-media-sources.js';
 /* eslint-disable no-unused-vars */
 
 QUnit.module('videojs-contrib-media-sources - HTML', {
@@ -35,7 +38,7 @@ QUnit.module('videojs-contrib-media-sources - HTML', {
         this.duration = NaN;
       },
       addSourceBuffer(type) {
-        let buffer = new (videojs.extend(videojs.EventTarget, {
+        let buffer = new(videojs.extend(videojs.EventTarget, {
           type,
           appendBuffer() {}
         }))();
@@ -133,22 +136,22 @@ QUnit.test('creates mp4 source buffers for mp2t segments', function() {
 });
 
 QUnit.test(
-'the terminate is called on the transmuxer when the media source is killed',
-function() {
-  let mediaSource = new videojs.MediaSource();
-  let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
-  let terminates = 0;
+  'the terminate is called on the transmuxer when the media source is killed',
+  function() {
+    let mediaSource = new videojs.MediaSource();
+    let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+    let terminates = 0;
 
-  sourceBuffer.transmuxer_ = {
-    terminate() {
-      terminates++;
-    }
-  };
+    sourceBuffer.transmuxer_ = {
+      terminate() {
+        terminates++;
+      }
+    };
 
-  mediaSource.trigger('sourceclose');
+    mediaSource.trigger('sourceclose');
 
-  QUnit.equal(terminates, 1, 'called terminate on transmux web worker');
-});
+    QUnit.equal(terminates, 1, 'called terminate on transmux web worker');
+  });
 
 QUnit.test('duration is faked when playing a live stream', function() {
   let mediaSource = new videojs.MediaSource();
@@ -157,21 +160,22 @@ QUnit.test('duration is faked when playing a live stream', function() {
   mediaSource.duration = Infinity;
   mediaSource.nativeMediaSource_.duration = 100;
   QUnit.equal(mediaSource.nativeMediaSource_.duration, 100,
-              'native duration was not set to infinity');
+    'native duration was not set to infinity');
   QUnit.equal(mediaSource.duration, Infinity,
-              'the MediaSource wrapper pretends it has an infinite duration');
+    'the MediaSource wrapper pretends it has an infinite duration');
 });
 
 QUnit.test(
-'duration uses the underlying MediaSource\'s duration when not live', function() {
-  let mediaSource = new videojs.MediaSource();
-  let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+  'duration uses the underlying MediaSource\'s duration when not live',
+  function() {
+    let mediaSource = new videojs.MediaSource();
+    let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
 
-  mediaSource.duration = 100;
-  mediaSource.nativeMediaSource_.duration = 120;
-  QUnit.equal(mediaSource.duration, 120,
-              'the MediaSource wrapper returns the native duration');
-});
+    mediaSource.duration = 100;
+    mediaSource.nativeMediaSource_.duration = 120;
+    QUnit.equal(mediaSource.duration, 120,
+      'the MediaSource wrapper returns the native duration');
+  });
 
 QUnit.test('abort on the fake source buffer calls abort on the real ones', function() {
   let mediaSource = new videojs.MediaSource();
@@ -205,50 +209,55 @@ QUnit.test('abort on the fake source buffer calls abort on the real ones', funct
 });
 
 QUnit.test(
-'calling remove deletes cues and invokes remove on any extant source buffers',
-function() {
-  let mediaSource = new videojs.MediaSource();
-  let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
-  let removedCue = [];
-  let removes = 0;
+  'calling remove deletes cues and invokes remove on any extant source buffers',
+  function() {
+    let mediaSource = new videojs.MediaSource();
+    let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+    let removedCue = [];
+    let removes = 0;
 
-  initializeNativeSourceBuffers(sourceBuffer);
+    initializeNativeSourceBuffers(sourceBuffer);
 
-  sourceBuffer.inbandTextTrack_ = {
-    removeCue(cue) {
-      removedCue.push(cue);
-      this.cues.splice(this.cues.indexOf(cue), 1);
-    },
-    cues: [
-      {startTime: 10, endTime: 20, text: 'delete me'},
-      {startTime: 0, endTime: 2, text: 'save me'}
-    ]
-  };
-  mediaSource.videoBuffer_.remove = function(start, end) {
-    if (start === 3 && end === 10) {
-      removes++;
-    }
-  };
-  mediaSource.audioBuffer_.remove = function(start, end) {
-    if (start === 3 && end === 10) {
-      removes++;
-    }
-  };
+    sourceBuffer.inbandTextTrack_ = {
+      removeCue(cue) {
+        removedCue.push(cue);
+        this.cues.splice(this.cues.indexOf(cue), 1);
+      },
+      cues: [{
+        startTime: 10,
+        endTime: 20,
+        text: 'delete me'
+      }, {
+        startTime: 0,
+        endTime: 2,
+        text: 'save me'
+      }]
+    };
+    mediaSource.videoBuffer_.remove = function(start, end) {
+      if (start === 3 && end === 10) {
+        removes++;
+      }
+    };
+    mediaSource.audioBuffer_.remove = function(start, end) {
+      if (start === 3 && end === 10) {
+        removes++;
+      }
+    };
 
-  sourceBuffer.remove(3, 10);
+    sourceBuffer.remove(3, 10);
 
-  QUnit.equal(removes, 2, 'called remove on both sourceBuffers');
-  QUnit.equal(
-    sourceBuffer.inbandTextTrack_.cues.length,
-    1,
-    'one cue remains after remove'
-  );
-  QUnit.equal(
-    removedCue[0].text,
-    'delete me',
-    'the cue that overlapped the remove region was removed'
-  );
-});
+    QUnit.equal(removes, 2, 'called remove on both sourceBuffers');
+    QUnit.equal(
+      sourceBuffer.inbandTextTrack_.cues.length,
+      1,
+      'one cue remains after remove'
+    );
+    QUnit.equal(
+      removedCue[0].text,
+      'delete me',
+      'the cue that overlapped the remove region was removed'
+    );
+  });
 
 QUnit.test('readyState delegates to the native implementation', function() {
   let mediaSource = new HtmlMediaSource();
@@ -337,64 +346,64 @@ QUnit.test('transmuxes mp2t segments', function() {
 });
 
 QUnit.test(
-'handles typed-arrays that are subsets of their underlying buffer',
-function() {
-  let mp2tSegments = [];
-  let mp4Segments = [];
-  let dataBuffer = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-  let data = dataBuffer.subarray(5, 7);
-  let mediaSource;
-  let sourceBuffer;
+  'handles typed-arrays that are subsets of their underlying buffer',
+  function() {
+    let mp2tSegments = [];
+    let mp4Segments = [];
+    let dataBuffer = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    let data = dataBuffer.subarray(5, 7);
+    let mediaSource;
+    let sourceBuffer;
 
-  mediaSource = new videojs.MediaSource();
-  sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+    mediaSource = new videojs.MediaSource();
+    sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
 
-  sourceBuffer.transmuxer_.postMessage = function(segment) {
-    if (segment.action === 'push') {
-      let buffer = new Uint8Array(segment.data, segment.byteOffset, segment.byteLength);
+    sourceBuffer.transmuxer_.postMessage = function(segment) {
+      if (segment.action === 'push') {
+        let buffer = new Uint8Array(segment.data, segment.byteOffset, segment.byteLength);
 
-      mp2tSegments.push(buffer);
-    }
-  };
+        mp2tSegments.push(buffer);
+      }
+    };
 
-  sourceBuffer.concatAndAppendSegments_ = function(segmentObj, destinationBuffer) {
-    mp4Segments.push(segmentObj.segments[0]);
-  };
+    sourceBuffer.concatAndAppendSegments_ = function(segmentObj, destinationBuffer) {
+      mp4Segments.push(segmentObj.segments[0]);
+    };
 
-  sourceBuffer.appendBuffer(data);
+    sourceBuffer.appendBuffer(data);
 
-  QUnit.equal(mp2tSegments.length, 1, 'emitted the fragment');
-  QUnit.equal(
-    mp2tSegments[0].length,
-    2,
-    'correctly handled a typed-array that is a subset'
-  );
-  QUnit.equal(mp2tSegments[0][0], 5, 'fragment contains the correct first byte');
-  QUnit.equal(mp2tSegments[0][1], 6, 'fragment contains the correct second byte');
+    QUnit.equal(mp2tSegments.length, 1, 'emitted the fragment');
+    QUnit.equal(
+      mp2tSegments[0].length,
+      2,
+      'correctly handled a typed-array that is a subset'
+    );
+    QUnit.equal(mp2tSegments[0][0], 5, 'fragment contains the correct first byte');
+    QUnit.equal(mp2tSegments[0][1], 6, 'fragment contains the correct second byte');
 
-  // an init segment
-  sourceBuffer.transmuxer_.onmessage(createDataMessage('video', data));
+    // an init segment
+    sourceBuffer.transmuxer_.onmessage(createDataMessage('video', data));
 
-  // Segments are concatenated
-  QUnit.equal(
-    mp4Segments.length,
-    0,
-    'segments are not appended until after the `done` message'
-  );
+    // Segments are concatenated
+    QUnit.equal(
+      mp4Segments.length,
+      0,
+      'segments are not appended until after the `done` message'
+    );
 
-  // send `done` message
-  sourceBuffer.transmuxer_.onmessage(doneMessage);
+    // send `done` message
+    sourceBuffer.transmuxer_.onmessage(doneMessage);
 
-  // Segments are concatenated
-  QUnit.equal(mp4Segments.length, 1, 'emitted the fragment');
-  QUnit.equal(
-    mp4Segments[0].length,
-    2,
-    'correctly handled a typed-array that is a subset'
-  );
-  QUnit.equal(mp4Segments[0][0], 5, 'fragment contains the correct first byte');
-  QUnit.equal(mp4Segments[0][1], 6, 'fragment contains the correct second byte');
-});
+    // Segments are concatenated
+    QUnit.equal(mp4Segments.length, 1, 'emitted the fragment');
+    QUnit.equal(
+      mp4Segments[0].length,
+      2,
+      'correctly handled a typed-array that is a subset'
+    );
+    QUnit.equal(mp4Segments[0][0], 5, 'fragment contains the correct first byte');
+    QUnit.equal(mp4Segments[0][1], 6, 'fragment contains the correct second byte');
+  });
 
 QUnit.test('handles empty codec string value', function() {
   let mediaSource = new videojs.MediaSource();
@@ -535,13 +544,13 @@ QUnit.test('forwards codec strings to native buffers when specified', function()
 
   QUnit.ok(mediaSource.videoBuffer_, 'created a video buffer');
   QUnit.equal(mediaSource.videoBuffer_.type,
-              'video/mp4;codecs="avc1.64001f"',
-              'passed the video codec along');
+    'video/mp4;codecs="avc1.64001f"',
+    'passed the video codec along');
 
   QUnit.ok(mediaSource.audioBuffer_, 'created a video buffer');
   QUnit.equal(mediaSource.audioBuffer_.type,
-              'audio/mp4;codecs="mp4a.40.5"',
-              'passed the audio codec along');
+    'audio/mp4;codecs="mp4a.40.5"',
+    'passed the audio codec along');
 });
 
 QUnit.test('parses old-school apple codec strings to the modern standard', function() {
@@ -553,13 +562,13 @@ QUnit.test('parses old-school apple codec strings to the modern standard', funct
 
   QUnit.ok(mediaSource.videoBuffer_, 'created a video buffer');
   QUnit.equal(mediaSource.videoBuffer_.type,
-              'video/mp4;codecs="avc1.64001f"',
-              'passed the video codec along');
+    'video/mp4;codecs="avc1.64001f"',
+    'passed the video codec along');
 
   QUnit.ok(mediaSource.audioBuffer_, 'created a video buffer');
   QUnit.equal(mediaSource.audioBuffer_.type,
-              'audio/mp4;codecs="mp4a.40.5"',
-              'passed the audio codec along');
+    'audio/mp4;codecs="mp4a.40.5"',
+    'passed the audio codec along');
 
 });
 
@@ -571,13 +580,13 @@ QUnit.test('specifies reasonable codecs if none are specified', function() {
 
   QUnit.ok(mediaSource.videoBuffer_, 'created a video buffer');
   QUnit.equal(mediaSource.videoBuffer_.type,
-              'video/mp4;codecs="avc1.4d400d"',
-              'passed the video codec along');
+    'video/mp4;codecs="avc1.4d400d"',
+    'passed the video codec along');
 
   QUnit.ok(mediaSource.audioBuffer_, 'created a video buffer');
   QUnit.equal(mediaSource.audioBuffer_.type,
-              'audio/mp4;codecs="mp4a.40.2"',
-              'passed the audio codec along');
+    'audio/mp4;codecs="mp4a.40.2"',
+    'passed the audio codec along');
 });
 
 QUnit.test('virtual buffers are updating if either native buffer is', function() {
@@ -601,29 +610,29 @@ QUnit.test('virtual buffers are updating if either native buffer is', function()
 });
 
 QUnit.test(
-'virtual buffers have a position buffered if both native buffers do',
-function() {
-  let mediaSource = new videojs.MediaSource();
-  let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+  'virtual buffers have a position buffered if both native buffers do',
+  function() {
+    let mediaSource = new videojs.MediaSource();
+    let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
 
-  initializeNativeSourceBuffers(sourceBuffer);
+    initializeNativeSourceBuffers(sourceBuffer);
 
-  mediaSource.videoBuffer_.buffered = videojs.createTimeRanges([
-    [0, 10],
-    [20, 30]
-  ]);
-  mediaSource.audioBuffer_.buffered = videojs.createTimeRanges([
-    [0, 7],
-    [11, 15],
-    [16, 40]
-  ]);
+    mediaSource.videoBuffer_.buffered = videojs.createTimeRanges([
+      [0, 10],
+      [20, 30]
+    ]);
+    mediaSource.audioBuffer_.buffered = videojs.createTimeRanges([
+      [0, 7],
+      [11, 15],
+      [16, 40]
+    ]);
 
-  QUnit.equal(sourceBuffer.buffered.length, 2, 'two buffered ranges');
-  QUnit.equal(sourceBuffer.buffered.start(0), 0, 'first starts at zero');
-  QUnit.equal(sourceBuffer.buffered.end(0), 7, 'first ends at seven');
-  QUnit.equal(sourceBuffer.buffered.start(1), 20, 'second starts at twenty');
-  QUnit.equal(sourceBuffer.buffered.end(1), 30, 'second ends at 30');
-});
+    QUnit.equal(sourceBuffer.buffered.length, 2, 'two buffered ranges');
+    QUnit.equal(sourceBuffer.buffered.start(0), 0, 'first starts at zero');
+    QUnit.equal(sourceBuffer.buffered.end(0), 7, 'first ends at seven');
+    QUnit.equal(sourceBuffer.buffered.start(1), 20, 'second starts at twenty');
+    QUnit.equal(sourceBuffer.buffered.end(1), 30, 'second ends at 30');
+  });
 
 QUnit.test('sets transmuxer baseMediaDecodeTime on appends', function() {
   let mediaSource = new videojs.MediaSource();
@@ -779,20 +788,20 @@ QUnit.test('translates metadata events into WebVTT cues', function() {
   QUnit.equal(
     sourceBuffer.metadataTrack_.inBandMetadataTrackDispatchType,
     16,
-  'in-band metadata track dispatch type correctly set'
+    'in-band metadata track dispatch type correctly set'
   );
   QUnit.equal(types.length, 1, 'created one text track');
   QUnit.equal(types[0], 'metadata', 'the type was metadata');
   QUnit.equal(cues.length, 3, 'created three cues');
   QUnit.equal(cues[0].text, 'This is a url tag', 'included the text');
   QUnit.equal(cues[0].startTime, 12, 'started at twelve');
-  QUnit.equal(cues[0].endTime, 12, 'ended at twelve');
+  QUnit.equal(cues[0].endTime, Number.MAX_VALUE, 'ended at the duration of the video');
   QUnit.equal(cues[1].text, 'This is a text tag', 'included the text');
   QUnit.equal(cues[1].startTime, 12, 'started at twelve');
-  QUnit.equal(cues[1].endTime, 12, 'ended at twelve');
+  QUnit.equal(cues[1].endTime, Number.MAX_VALUE, 'ended at the duration of the video');
   QUnit.equal(cues[2].text, 'This is a priv tag', 'included the text');
   QUnit.equal(cues[2].startTime, 22, 'started at twenty two');
-  QUnit.equal(cues[2].endTime, 22, 'ended at twenty two');
+  QUnit.equal(cues[2].endTime, Number.MAX_VALUE, 'ended at the duration of the video');
 });
 
 QUnit.test('does not wrap mp4 source buffers', function() {
@@ -817,180 +826,188 @@ QUnit.test('can get activeSourceBuffers', function() {
 });
 
 QUnit.test('active source buffers are updated on each buffer\'s updateend',
-function() {
-  let mediaSource = new videojs.MediaSource();
-  let updateCallCount = 0;
-  let sourceBuffer;
+  function() {
+    let mediaSource = new videojs.MediaSource();
+    let updateCallCount = 0;
+    let sourceBuffer;
 
-  mediaSource.updateActiveSourceBuffers_ = () => {
-    updateCallCount++;
-  };
+    mediaSource.updateActiveSourceBuffers_ = () => {
+      updateCallCount++;
+    };
 
-  sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
-  mediaSource.player_ = this.player;
-  mediaSource.url_ = this.url;
-  mediaSource.trigger('sourceopen');
-  QUnit.equal(updateCallCount, 0,
-              'active source buffers not updated on adding source buffer');
+    sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+    mediaSource.player_ = this.player;
+    mediaSource.url_ = this.url;
+    mediaSource.trigger('sourceopen');
+    QUnit.equal(updateCallCount, 0,
+      'active source buffers not updated on adding source buffer');
 
-  mediaSource.player_.audioTracks().trigger('addtrack');
-  QUnit.equal(updateCallCount, 1,
-              'active source buffers updated after addtrack');
+    mediaSource.player_.audioTracks().trigger('addtrack');
+    QUnit.equal(updateCallCount, 1,
+      'active source buffers updated after addtrack');
 
-  sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
-  QUnit.equal(updateCallCount, 1,
-              'active source buffers not updated on adding second source buffer');
+    sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+    QUnit.equal(updateCallCount, 1,
+      'active source buffers not updated on adding second source buffer');
 
-  mediaSource.player_.audioTracks().trigger('removetrack');
-  QUnit.equal(updateCallCount, 2,
-              'active source buffers updated after removetrack');
+    mediaSource.player_.audioTracks().trigger('removetrack');
+    QUnit.equal(updateCallCount, 2,
+      'active source buffers updated after removetrack');
 
-  mediaSource.player_.audioTracks().trigger('change');
-  QUnit.equal(updateCallCount, 3,
-              'active source buffers updated after change');
+    mediaSource.player_.audioTracks().trigger('change');
+    QUnit.equal(updateCallCount, 3,
+      'active source buffers updated after change');
 
-});
+  });
 
 QUnit.test('combined buffer is the only active buffer when main track enabled',
-function() {
-  let mediaSource = new videojs.MediaSource();
-  let sourceBufferAudio;
-  let sourceBufferCombined;
-  let audioTracks = [{
-    enabled: true,
-    kind: 'main',
-    label: 'main'
-  }, {
-    enabled: false,
-    kind: 'alternative',
-    label: 'English (UK)'
-  }];
+  function() {
+    let mediaSource = new videojs.MediaSource();
+    let sourceBufferAudio;
+    let sourceBufferCombined;
+    let audioTracks = [{
+      enabled: true,
+      kind: 'main',
+      label: 'main'
+    }, {
+      enabled: false,
+      kind: 'alternative',
+      label: 'English (UK)'
+    }];
 
-  this.player.audioTracks = () => audioTracks;
+    this.player.audioTracks = () => audioTracks;
 
-  mediaSource.player_ = this.player;
+    mediaSource.player_ = this.player;
 
-  sourceBufferCombined = mediaSource.addSourceBuffer('video/m2pt');
-  sourceBufferCombined.videoCodec_ = true;
-  sourceBufferCombined.audioCodec_ = true;
-  sourceBufferAudio = mediaSource.addSourceBuffer('video/m2pt');
-  sourceBufferAudio.videoCodec_ = false;
-  sourceBufferAudio.audioCodec_ = true;
+    sourceBufferCombined = mediaSource.addSourceBuffer('video/m2pt');
+    sourceBufferCombined.videoCodec_ = true;
+    sourceBufferCombined.audioCodec_ = true;
+    sourceBufferAudio = mediaSource.addSourceBuffer('video/m2pt');
+    sourceBufferAudio.videoCodec_ = false;
+    sourceBufferAudio.audioCodec_ = true;
 
-  mediaSource.updateActiveSourceBuffers_();
+    mediaSource.updateActiveSourceBuffers_();
 
-  QUnit.equal(mediaSource.activeSourceBuffers.length, 1,
-    'active source buffers starts with one source buffer');
-  QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
-    'active source buffers starts with combined source buffer');
-});
+    QUnit.equal(mediaSource.activeSourceBuffers.length, 1,
+      'active source buffers starts with one source buffer');
+    QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
+      'active source buffers starts with combined source buffer');
+  });
 
 QUnit.test('combined & audio buffers are active when alternative track enabled',
-function() {
-  let mediaSource = new videojs.MediaSource();
-  let sourceBufferAudio;
-  let sourceBufferCombined;
-  let audioTracks = [{
-    enabled: false,
-    kind: 'main',
-    label: 'main'
-  }, {
-    enabled: true,
-    kind: 'alternative',
-    label: 'English (UK)'
-  }];
+  function() {
+    let mediaSource = new videojs.MediaSource();
+    let sourceBufferAudio;
+    let sourceBufferCombined;
+    let audioTracks = [{
+      enabled: false,
+      kind: 'main',
+      label: 'main'
+    }, {
+      enabled: true,
+      kind: 'alternative',
+      label: 'English (UK)'
+    }];
 
-  this.player.audioTracks = () => audioTracks;
+    this.player.audioTracks = () => audioTracks;
 
-  mediaSource.player_ = this.player;
+    mediaSource.player_ = this.player;
 
-  sourceBufferCombined = mediaSource.addSourceBuffer('video/m2pt');
-  sourceBufferCombined.videoCodec_ = true;
-  sourceBufferCombined.audioCodec_ = true;
-  sourceBufferAudio = mediaSource.addSourceBuffer('video/m2pt');
-  sourceBufferAudio.videoCodec_ = false;
-  sourceBufferAudio.audioCodec_ = true;
+    sourceBufferCombined = mediaSource.addSourceBuffer('video/m2pt');
+    sourceBufferCombined.videoCodec_ = true;
+    sourceBufferCombined.audioCodec_ = true;
+    sourceBufferAudio = mediaSource.addSourceBuffer('video/m2pt');
+    sourceBufferAudio.videoCodec_ = false;
+    sourceBufferAudio.audioCodec_ = true;
 
-  mediaSource.updateActiveSourceBuffers_();
+    mediaSource.updateActiveSourceBuffers_();
 
-  QUnit.equal(mediaSource.activeSourceBuffers.length, 2,
-    'active source buffers includes both source buffers');
-  // maintains same order as source buffers were created
-  QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
-    'active source buffers starts with combined source buffer');
-  QUnit.equal(mediaSource.activeSourceBuffers[1], sourceBufferAudio,
-    'active source buffers ends with audio source buffer');
-});
+    QUnit.equal(mediaSource.activeSourceBuffers.length, 2,
+      'active source buffers includes both source buffers');
+    // maintains same order as source buffers were created
+    QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
+      'active source buffers starts with combined source buffer');
+    QUnit.equal(mediaSource.activeSourceBuffers[1], sourceBufferAudio,
+      'active source buffers ends with audio source buffer');
+  });
 
 QUnit.test('video only & audio only buffers are always active',
-function() {
-  let mediaSource = new videojs.MediaSource();
-  let sourceBufferAudio;
-  let sourceBufferCombined;
-  let audioTracks = [{
-    enabled: false,
-    kind: 'main',
-    label: 'main'
-  }, {
-    enabled: true,
-    kind: 'alternative',
-    label: 'English (UK)'
-  }];
+  function() {
+    let mediaSource = new videojs.MediaSource();
+    let sourceBufferAudio;
+    let sourceBufferCombined;
+    let audioTracks = [{
+      enabled: false,
+      kind: 'main',
+      label: 'main'
+    }, {
+      enabled: true,
+      kind: 'alternative',
+      label: 'English (UK)'
+    }];
 
-  this.player.audioTracks = () => audioTracks;
+    this.player.audioTracks = () => audioTracks;
 
-  mediaSource.player_ = this.player;
+    mediaSource.player_ = this.player;
 
-  sourceBufferCombined = mediaSource.addSourceBuffer('video/m2pt');
-  sourceBufferCombined.videoCodec_ = true;
-  sourceBufferCombined.audioCodec_ = false;
-  sourceBufferAudio = mediaSource.addSourceBuffer('video/m2pt');
-  sourceBufferAudio.videoCodec_ = false;
-  sourceBufferAudio.audioCodec_ = true;
+    sourceBufferCombined = mediaSource.addSourceBuffer('video/m2pt');
+    sourceBufferCombined.videoCodec_ = true;
+    sourceBufferCombined.audioCodec_ = false;
+    sourceBufferAudio = mediaSource.addSourceBuffer('video/m2pt');
+    sourceBufferAudio.videoCodec_ = false;
+    sourceBufferAudio.audioCodec_ = true;
 
-  mediaSource.updateActiveSourceBuffers_();
+    mediaSource.updateActiveSourceBuffers_();
 
-  QUnit.equal(mediaSource.activeSourceBuffers.length, 2,
-    'active source buffers includes both source buffers');
-  // maintains same order as source buffers were created
-  QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
-    'active source buffers starts with combined source buffer');
-  QUnit.equal(mediaSource.activeSourceBuffers[1], sourceBufferAudio,
-    'active source buffers ends with audio source buffer');
+    QUnit.equal(mediaSource.activeSourceBuffers.length, 2,
+      'active source buffers includes both source buffers');
+    // maintains same order as source buffers were created
+    QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
+      'active source buffers starts with combined source buffer');
+    QUnit.equal(mediaSource.activeSourceBuffers[1], sourceBufferAudio,
+      'active source buffers ends with audio source buffer');
 
-  audioTracks[0].enabled = true;
-  audioTracks[1].enabled = false;
-  mediaSource.updateActiveSourceBuffers_();
+    audioTracks[0].enabled = true;
+    audioTracks[1].enabled = false;
+    mediaSource.updateActiveSourceBuffers_();
 
-  QUnit.equal(mediaSource.activeSourceBuffers.length, 2,
-    'active source buffers includes both source buffers');
-  // maintains same order as source buffers were created
-  QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
-    'active source buffers starts with combined source buffer');
-  QUnit.equal(mediaSource.activeSourceBuffers[1], sourceBufferAudio,
-    'active source buffers ends with audio source buffer');
+    QUnit.equal(mediaSource.activeSourceBuffers.length, 2,
+      'active source buffers includes both source buffers');
+    // maintains same order as source buffers were created
+    QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
+      'active source buffers starts with combined source buffer');
+    QUnit.equal(mediaSource.activeSourceBuffers[1], sourceBufferAudio,
+      'active source buffers ends with audio source buffer');
 
-});
+  });
 
 QUnit.test('video segments with info trigger videooinfo event', function() {
   let data = new Uint8Array(1);
   let infoEvents = [];
   let mediaSource = new videojs.MediaSource();
   let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
-  let info = {width: 100};
-  let newinfo = {width: 225};
+  let info = {
+    width: 100
+  };
+  let newinfo = {
+    width: 225
+  };
 
   mediaSource.on('videoinfo', (e) => infoEvents.push(e));
 
   // send an audio segment with info, then send done
-  sourceBuffer.transmuxer_.onmessage(createDataMessage('video', data, {info}));
+  sourceBuffer.transmuxer_.onmessage(createDataMessage('video', data, {
+    info
+  }));
   sourceBuffer.transmuxer_.onmessage(doneMessage);
 
   QUnit.equal(infoEvents.length, 1, 'video info should trigger');
   QUnit.deepEqual(infoEvents[0].info, info, 'video info = muxed info');
 
   // send an audio segment with info, then send done
-  sourceBuffer.transmuxer_.onmessage(createDataMessage('video', data, {info: newinfo}));
+  sourceBuffer.transmuxer_.onmessage(createDataMessage('video', data, {
+    info: newinfo
+  }));
   sourceBuffer.transmuxer_.onmessage(doneMessage);
 
   QUnit.equal(infoEvents.length, 2, 'video info should trigger');
@@ -1002,20 +1019,28 @@ QUnit.test('audio segments with info trigger audioinfo event', function() {
   let infoEvents = [];
   let mediaSource = new videojs.MediaSource();
   let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
-  let info = {width: 100};
-  let newinfo = {width: 225};
+  let info = {
+    width: 100
+  };
+  let newinfo = {
+    width: 225
+  };
 
   mediaSource.on('audioinfo', (e) => infoEvents.push(e));
 
   // send an audio segment with info, then send done
-  sourceBuffer.transmuxer_.onmessage(createDataMessage('audio', data, {info}));
+  sourceBuffer.transmuxer_.onmessage(createDataMessage('audio', data, {
+    info
+  }));
   sourceBuffer.transmuxer_.onmessage(doneMessage);
 
   QUnit.equal(infoEvents.length, 1, 'audio info should trigger');
   QUnit.deepEqual(infoEvents[0].info, info, 'audio info = muxed info');
 
   // send an audio segment with info, then send done
-  sourceBuffer.transmuxer_.onmessage(createDataMessage('audio', data, {info: newinfo}));
+  sourceBuffer.transmuxer_.onmessage(createDataMessage('audio', data, {
+    info: newinfo
+  }));
   sourceBuffer.transmuxer_.onmessage(doneMessage);
 
   QUnit.equal(infoEvents.length, 2, 'audio info should trigger');
@@ -1023,40 +1048,41 @@ QUnit.test('audio segments with info trigger audioinfo event', function() {
 });
 
 QUnit.test('creates native SourceBuffers immediately if a second ' +
-           'VirtualSourceBuffer is created', function() {
-  let mediaSource = new videojs.MediaSource();
-  let sourceBuffer =
-    mediaSource.addSourceBuffer('video/mp2t; codecs="avc1.64001f,mp4a.40.5"');
-  let sourceBuffer2 =
-    mediaSource.addSourceBuffer('video/mp2t; codecs="mp4a.40.5"');
+  'VirtualSourceBuffer is created',
+  function() {
+    let mediaSource = new videojs.MediaSource();
+    let sourceBuffer =
+      mediaSource.addSourceBuffer('video/mp2t; codecs="avc1.64001f,mp4a.40.5"');
+    let sourceBuffer2 =
+      mediaSource.addSourceBuffer('video/mp2t; codecs="mp4a.40.5"');
 
-  QUnit.ok(mediaSource.videoBuffer_, 'created a video buffer');
-  QUnit.equal(
-    mediaSource.videoBuffer_.type,
-    'video/mp4;codecs="avc1.64001f"',
-    'video buffer has the specified codec'
-  );
+    QUnit.ok(mediaSource.videoBuffer_, 'created a video buffer');
+    QUnit.equal(
+      mediaSource.videoBuffer_.type,
+      'video/mp4;codecs="avc1.64001f"',
+      'video buffer has the specified codec'
+    );
 
-  QUnit.ok(mediaSource.audioBuffer_, 'created an audio buffer');
-  QUnit.equal(
-    mediaSource.audioBuffer_.type,
-    'audio/mp4;codecs="mp4a.40.5"',
-    'audio buffer has the specified codec'
-  );
-  QUnit.equal(mediaSource.sourceBuffers.length, 2, 'created two virtual buffers');
-  QUnit.equal(
-    mediaSource.sourceBuffers[0],
-    sourceBuffer,
-    'returned the virtual buffer');
-  QUnit.equal(
-    mediaSource.sourceBuffers[1],
-    sourceBuffer2,
-    'returned the virtual buffer');
-  QUnit.equal(
-    sourceBuffer.audioDisabled_,
-    true,
-    'first source buffer\'s audio is automatically disabled');
-  QUnit.ok(
-    sourceBuffer2.audioBuffer_,
-    'second source buffer has an audio source buffer');
-});
+    QUnit.ok(mediaSource.audioBuffer_, 'created an audio buffer');
+    QUnit.equal(
+      mediaSource.audioBuffer_.type,
+      'audio/mp4;codecs="mp4a.40.5"',
+      'audio buffer has the specified codec'
+    );
+    QUnit.equal(mediaSource.sourceBuffers.length, 2, 'created two virtual buffers');
+    QUnit.equal(
+      mediaSource.sourceBuffers[0],
+      sourceBuffer,
+      'returned the virtual buffer');
+    QUnit.equal(
+      mediaSource.sourceBuffers[1],
+      sourceBuffer2,
+      'returned the virtual buffer');
+    QUnit.equal(
+      sourceBuffer.audioDisabled_,
+      true,
+      'first source buffer\'s audio is automatically disabled');
+    QUnit.ok(
+      sourceBuffer2.audioBuffer_,
+      'second source buffer has an audio source buffer');
+  });

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -742,6 +742,7 @@ QUnit.test('translates caption events into WebVTT cues', function() {
 QUnit.test('translates metadata events into WebVTT cues', function() {
   let mediaSource = new videojs.MediaSource();
   let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+
   mediaSource.duration = 50;
   mediaSource.nativeMediaSource_.duration = 60;
 
@@ -785,7 +786,7 @@ QUnit.test('translates metadata events into WebVTT cues', function() {
   'in-band metadata track dispatch type correctly set'
   );
   let cues = sourceBuffer.metadataTrack_.cues;
-  
+
   QUnit.equal(types.length, 1, 'created one text track');
   QUnit.equal(types[0], 'metadata', 'the type was metadata');
   QUnit.equal(cues.length, 3, 'created three cues');

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -8,10 +8,7 @@ import HtmlMediaSource from '../src/html-media-source';
 // we disable this because browserify needs to include these files
 // but the exports are not important
 /* eslint-disable no-unused-vars */
-import {
-  MediaSource,
-  URL
-} from '../src/videojs-contrib-media-sources.js';
+import {MediaSource, URL} from '../src/videojs-contrib-media-sources.js';
 /* eslint-disable no-unused-vars */
 
 QUnit.module('videojs-contrib-media-sources - HTML', {
@@ -38,7 +35,7 @@ QUnit.module('videojs-contrib-media-sources - HTML', {
         this.duration = NaN;
       },
       addSourceBuffer(type) {
-        let buffer = new(videojs.extend(videojs.EventTarget, {
+        let buffer = new (videojs.extend(videojs.EventTarget, {
           type,
           appendBuffer() {}
         }))();
@@ -136,22 +133,22 @@ QUnit.test('creates mp4 source buffers for mp2t segments', function() {
 });
 
 QUnit.test(
-  'the terminate is called on the transmuxer when the media source is killed',
-  function() {
-    let mediaSource = new videojs.MediaSource();
-    let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
-    let terminates = 0;
+'the terminate is called on the transmuxer when the media source is killed',
+function() {
+  let mediaSource = new videojs.MediaSource();
+  let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+  let terminates = 0;
 
-    sourceBuffer.transmuxer_ = {
-      terminate() {
-        terminates++;
-      }
-    };
+  sourceBuffer.transmuxer_ = {
+    terminate() {
+      terminates++;
+    }
+  };
 
-    mediaSource.trigger('sourceclose');
+  mediaSource.trigger('sourceclose');
 
-    QUnit.equal(terminates, 1, 'called terminate on transmux web worker');
-  });
+  QUnit.equal(terminates, 1, 'called terminate on transmux web worker');
+});
 
 QUnit.test('duration is faked when playing a live stream', function() {
   let mediaSource = new videojs.MediaSource();
@@ -160,22 +157,21 @@ QUnit.test('duration is faked when playing a live stream', function() {
   mediaSource.duration = Infinity;
   mediaSource.nativeMediaSource_.duration = 100;
   QUnit.equal(mediaSource.nativeMediaSource_.duration, 100,
-    'native duration was not set to infinity');
+              'native duration was not set to infinity');
   QUnit.equal(mediaSource.duration, Infinity,
-    'the MediaSource wrapper pretends it has an infinite duration');
+              'the MediaSource wrapper pretends it has an infinite duration');
 });
 
 QUnit.test(
-  'duration uses the underlying MediaSource\'s duration when not live',
-  function() {
-    let mediaSource = new videojs.MediaSource();
-    let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+'duration uses the underlying MediaSource\'s duration when not live', function() {
+  let mediaSource = new videojs.MediaSource();
+  let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
 
-    mediaSource.duration = 100;
-    mediaSource.nativeMediaSource_.duration = 120;
-    QUnit.equal(mediaSource.duration, 120,
-      'the MediaSource wrapper returns the native duration');
-  });
+  mediaSource.duration = 100;
+  mediaSource.nativeMediaSource_.duration = 120;
+  QUnit.equal(mediaSource.duration, 120,
+              'the MediaSource wrapper returns the native duration');
+});
 
 QUnit.test('abort on the fake source buffer calls abort on the real ones', function() {
   let mediaSource = new videojs.MediaSource();
@@ -209,55 +205,50 @@ QUnit.test('abort on the fake source buffer calls abort on the real ones', funct
 });
 
 QUnit.test(
-  'calling remove deletes cues and invokes remove on any extant source buffers',
-  function() {
-    let mediaSource = new videojs.MediaSource();
-    let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
-    let removedCue = [];
-    let removes = 0;
+'calling remove deletes cues and invokes remove on any extant source buffers',
+function() {
+  let mediaSource = new videojs.MediaSource();
+  let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+  let removedCue = [];
+  let removes = 0;
 
-    initializeNativeSourceBuffers(sourceBuffer);
+  initializeNativeSourceBuffers(sourceBuffer);
 
-    sourceBuffer.inbandTextTrack_ = {
-      removeCue(cue) {
-        removedCue.push(cue);
-        this.cues.splice(this.cues.indexOf(cue), 1);
-      },
-      cues: [{
-        startTime: 10,
-        endTime: 20,
-        text: 'delete me'
-      }, {
-        startTime: 0,
-        endTime: 2,
-        text: 'save me'
-      }]
-    };
-    mediaSource.videoBuffer_.remove = function(start, end) {
-      if (start === 3 && end === 10) {
-        removes++;
-      }
-    };
-    mediaSource.audioBuffer_.remove = function(start, end) {
-      if (start === 3 && end === 10) {
-        removes++;
-      }
-    };
+  sourceBuffer.inbandTextTrack_ = {
+    removeCue(cue) {
+      removedCue.push(cue);
+      this.cues.splice(this.cues.indexOf(cue), 1);
+    },
+    cues: [
+      {startTime: 10, endTime: 20, text: 'delete me'},
+      {startTime: 0, endTime: 2, text: 'save me'}
+    ]
+  };
+  mediaSource.videoBuffer_.remove = function(start, end) {
+    if (start === 3 && end === 10) {
+      removes++;
+    }
+  };
+  mediaSource.audioBuffer_.remove = function(start, end) {
+    if (start === 3 && end === 10) {
+      removes++;
+    }
+  };
 
-    sourceBuffer.remove(3, 10);
+  sourceBuffer.remove(3, 10);
 
-    QUnit.equal(removes, 2, 'called remove on both sourceBuffers');
-    QUnit.equal(
-      sourceBuffer.inbandTextTrack_.cues.length,
-      1,
-      'one cue remains after remove'
-    );
-    QUnit.equal(
-      removedCue[0].text,
-      'delete me',
-      'the cue that overlapped the remove region was removed'
-    );
-  });
+  QUnit.equal(removes, 2, 'called remove on both sourceBuffers');
+  QUnit.equal(
+    sourceBuffer.inbandTextTrack_.cues.length,
+    1,
+    'one cue remains after remove'
+  );
+  QUnit.equal(
+    removedCue[0].text,
+    'delete me',
+    'the cue that overlapped the remove region was removed'
+  );
+});
 
 QUnit.test('readyState delegates to the native implementation', function() {
   let mediaSource = new HtmlMediaSource();
@@ -346,64 +337,64 @@ QUnit.test('transmuxes mp2t segments', function() {
 });
 
 QUnit.test(
-  'handles typed-arrays that are subsets of their underlying buffer',
-  function() {
-    let mp2tSegments = [];
-    let mp4Segments = [];
-    let dataBuffer = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    let data = dataBuffer.subarray(5, 7);
-    let mediaSource;
-    let sourceBuffer;
+'handles typed-arrays that are subsets of their underlying buffer',
+function() {
+  let mp2tSegments = [];
+  let mp4Segments = [];
+  let dataBuffer = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  let data = dataBuffer.subarray(5, 7);
+  let mediaSource;
+  let sourceBuffer;
 
-    mediaSource = new videojs.MediaSource();
-    sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+  mediaSource = new videojs.MediaSource();
+  sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
 
-    sourceBuffer.transmuxer_.postMessage = function(segment) {
-      if (segment.action === 'push') {
-        let buffer = new Uint8Array(segment.data, segment.byteOffset, segment.byteLength);
+  sourceBuffer.transmuxer_.postMessage = function(segment) {
+    if (segment.action === 'push') {
+      let buffer = new Uint8Array(segment.data, segment.byteOffset, segment.byteLength);
 
-        mp2tSegments.push(buffer);
-      }
-    };
+      mp2tSegments.push(buffer);
+    }
+  };
 
-    sourceBuffer.concatAndAppendSegments_ = function(segmentObj, destinationBuffer) {
-      mp4Segments.push(segmentObj.segments[0]);
-    };
+  sourceBuffer.concatAndAppendSegments_ = function(segmentObj, destinationBuffer) {
+    mp4Segments.push(segmentObj.segments[0]);
+  };
 
-    sourceBuffer.appendBuffer(data);
+  sourceBuffer.appendBuffer(data);
 
-    QUnit.equal(mp2tSegments.length, 1, 'emitted the fragment');
-    QUnit.equal(
-      mp2tSegments[0].length,
-      2,
-      'correctly handled a typed-array that is a subset'
-    );
-    QUnit.equal(mp2tSegments[0][0], 5, 'fragment contains the correct first byte');
-    QUnit.equal(mp2tSegments[0][1], 6, 'fragment contains the correct second byte');
+  QUnit.equal(mp2tSegments.length, 1, 'emitted the fragment');
+  QUnit.equal(
+    mp2tSegments[0].length,
+    2,
+    'correctly handled a typed-array that is a subset'
+  );
+  QUnit.equal(mp2tSegments[0][0], 5, 'fragment contains the correct first byte');
+  QUnit.equal(mp2tSegments[0][1], 6, 'fragment contains the correct second byte');
 
-    // an init segment
-    sourceBuffer.transmuxer_.onmessage(createDataMessage('video', data));
+  // an init segment
+  sourceBuffer.transmuxer_.onmessage(createDataMessage('video', data));
 
-    // Segments are concatenated
-    QUnit.equal(
-      mp4Segments.length,
-      0,
-      'segments are not appended until after the `done` message'
-    );
+  // Segments are concatenated
+  QUnit.equal(
+    mp4Segments.length,
+    0,
+    'segments are not appended until after the `done` message'
+  );
 
-    // send `done` message
-    sourceBuffer.transmuxer_.onmessage(doneMessage);
+  // send `done` message
+  sourceBuffer.transmuxer_.onmessage(doneMessage);
 
-    // Segments are concatenated
-    QUnit.equal(mp4Segments.length, 1, 'emitted the fragment');
-    QUnit.equal(
-      mp4Segments[0].length,
-      2,
-      'correctly handled a typed-array that is a subset'
-    );
-    QUnit.equal(mp4Segments[0][0], 5, 'fragment contains the correct first byte');
-    QUnit.equal(mp4Segments[0][1], 6, 'fragment contains the correct second byte');
-  });
+  // Segments are concatenated
+  QUnit.equal(mp4Segments.length, 1, 'emitted the fragment');
+  QUnit.equal(
+    mp4Segments[0].length,
+    2,
+    'correctly handled a typed-array that is a subset'
+  );
+  QUnit.equal(mp4Segments[0][0], 5, 'fragment contains the correct first byte');
+  QUnit.equal(mp4Segments[0][1], 6, 'fragment contains the correct second byte');
+});
 
 QUnit.test('handles empty codec string value', function() {
   let mediaSource = new videojs.MediaSource();
@@ -544,13 +535,13 @@ QUnit.test('forwards codec strings to native buffers when specified', function()
 
   QUnit.ok(mediaSource.videoBuffer_, 'created a video buffer');
   QUnit.equal(mediaSource.videoBuffer_.type,
-    'video/mp4;codecs="avc1.64001f"',
-    'passed the video codec along');
+              'video/mp4;codecs="avc1.64001f"',
+              'passed the video codec along');
 
   QUnit.ok(mediaSource.audioBuffer_, 'created a video buffer');
   QUnit.equal(mediaSource.audioBuffer_.type,
-    'audio/mp4;codecs="mp4a.40.5"',
-    'passed the audio codec along');
+              'audio/mp4;codecs="mp4a.40.5"',
+              'passed the audio codec along');
 });
 
 QUnit.test('parses old-school apple codec strings to the modern standard', function() {
@@ -562,13 +553,13 @@ QUnit.test('parses old-school apple codec strings to the modern standard', funct
 
   QUnit.ok(mediaSource.videoBuffer_, 'created a video buffer');
   QUnit.equal(mediaSource.videoBuffer_.type,
-    'video/mp4;codecs="avc1.64001f"',
-    'passed the video codec along');
+              'video/mp4;codecs="avc1.64001f"',
+              'passed the video codec along');
 
   QUnit.ok(mediaSource.audioBuffer_, 'created a video buffer');
   QUnit.equal(mediaSource.audioBuffer_.type,
-    'audio/mp4;codecs="mp4a.40.5"',
-    'passed the audio codec along');
+              'audio/mp4;codecs="mp4a.40.5"',
+              'passed the audio codec along');
 
 });
 
@@ -580,13 +571,13 @@ QUnit.test('specifies reasonable codecs if none are specified', function() {
 
   QUnit.ok(mediaSource.videoBuffer_, 'created a video buffer');
   QUnit.equal(mediaSource.videoBuffer_.type,
-    'video/mp4;codecs="avc1.4d400d"',
-    'passed the video codec along');
+              'video/mp4;codecs="avc1.4d400d"',
+              'passed the video codec along');
 
   QUnit.ok(mediaSource.audioBuffer_, 'created a video buffer');
   QUnit.equal(mediaSource.audioBuffer_.type,
-    'audio/mp4;codecs="mp4a.40.2"',
-    'passed the audio codec along');
+              'audio/mp4;codecs="mp4a.40.2"',
+              'passed the audio codec along');
 });
 
 QUnit.test('virtual buffers are updating if either native buffer is', function() {
@@ -610,29 +601,29 @@ QUnit.test('virtual buffers are updating if either native buffer is', function()
 });
 
 QUnit.test(
-  'virtual buffers have a position buffered if both native buffers do',
-  function() {
-    let mediaSource = new videojs.MediaSource();
-    let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+'virtual buffers have a position buffered if both native buffers do',
+function() {
+  let mediaSource = new videojs.MediaSource();
+  let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
 
-    initializeNativeSourceBuffers(sourceBuffer);
+  initializeNativeSourceBuffers(sourceBuffer);
 
-    mediaSource.videoBuffer_.buffered = videojs.createTimeRanges([
-      [0, 10],
-      [20, 30]
-    ]);
-    mediaSource.audioBuffer_.buffered = videojs.createTimeRanges([
-      [0, 7],
-      [11, 15],
-      [16, 40]
-    ]);
+  mediaSource.videoBuffer_.buffered = videojs.createTimeRanges([
+    [0, 10],
+    [20, 30]
+  ]);
+  mediaSource.audioBuffer_.buffered = videojs.createTimeRanges([
+    [0, 7],
+    [11, 15],
+    [16, 40]
+  ]);
 
-    QUnit.equal(sourceBuffer.buffered.length, 2, 'two buffered ranges');
-    QUnit.equal(sourceBuffer.buffered.start(0), 0, 'first starts at zero');
-    QUnit.equal(sourceBuffer.buffered.end(0), 7, 'first ends at seven');
-    QUnit.equal(sourceBuffer.buffered.start(1), 20, 'second starts at twenty');
-    QUnit.equal(sourceBuffer.buffered.end(1), 30, 'second ends at 30');
-  });
+  QUnit.equal(sourceBuffer.buffered.length, 2, 'two buffered ranges');
+  QUnit.equal(sourceBuffer.buffered.start(0), 0, 'first starts at zero');
+  QUnit.equal(sourceBuffer.buffered.end(0), 7, 'first ends at seven');
+  QUnit.equal(sourceBuffer.buffered.start(1), 20, 'second starts at twenty');
+  QUnit.equal(sourceBuffer.buffered.end(1), 30, 'second ends at 30');
+});
 
 QUnit.test('sets transmuxer baseMediaDecodeTime on appends', function() {
   let mediaSource = new videojs.MediaSource();
@@ -788,7 +779,7 @@ QUnit.test('translates metadata events into WebVTT cues', function() {
   QUnit.equal(
     sourceBuffer.metadataTrack_.inBandMetadataTrackDispatchType,
     16,
-    'in-band metadata track dispatch type correctly set'
+  'in-band metadata track dispatch type correctly set'
   );
   QUnit.equal(types.length, 1, 'created one text track');
   QUnit.equal(types[0], 'metadata', 'the type was metadata');
@@ -826,188 +817,180 @@ QUnit.test('can get activeSourceBuffers', function() {
 });
 
 QUnit.test('active source buffers are updated on each buffer\'s updateend',
-  function() {
-    let mediaSource = new videojs.MediaSource();
-    let updateCallCount = 0;
-    let sourceBuffer;
+function() {
+  let mediaSource = new videojs.MediaSource();
+  let updateCallCount = 0;
+  let sourceBuffer;
 
-    mediaSource.updateActiveSourceBuffers_ = () => {
-      updateCallCount++;
-    };
+  mediaSource.updateActiveSourceBuffers_ = () => {
+    updateCallCount++;
+  };
 
-    sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
-    mediaSource.player_ = this.player;
-    mediaSource.url_ = this.url;
-    mediaSource.trigger('sourceopen');
-    QUnit.equal(updateCallCount, 0,
-      'active source buffers not updated on adding source buffer');
+  sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+  mediaSource.player_ = this.player;
+  mediaSource.url_ = this.url;
+  mediaSource.trigger('sourceopen');
+  QUnit.equal(updateCallCount, 0,
+              'active source buffers not updated on adding source buffer');
 
-    mediaSource.player_.audioTracks().trigger('addtrack');
-    QUnit.equal(updateCallCount, 1,
-      'active source buffers updated after addtrack');
+  mediaSource.player_.audioTracks().trigger('addtrack');
+  QUnit.equal(updateCallCount, 1,
+              'active source buffers updated after addtrack');
 
-    sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
-    QUnit.equal(updateCallCount, 1,
-      'active source buffers not updated on adding second source buffer');
+  sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+  QUnit.equal(updateCallCount, 1,
+              'active source buffers not updated on adding second source buffer');
 
-    mediaSource.player_.audioTracks().trigger('removetrack');
-    QUnit.equal(updateCallCount, 2,
-      'active source buffers updated after removetrack');
+  mediaSource.player_.audioTracks().trigger('removetrack');
+  QUnit.equal(updateCallCount, 2,
+              'active source buffers updated after removetrack');
 
-    mediaSource.player_.audioTracks().trigger('change');
-    QUnit.equal(updateCallCount, 3,
-      'active source buffers updated after change');
+  mediaSource.player_.audioTracks().trigger('change');
+  QUnit.equal(updateCallCount, 3,
+              'active source buffers updated after change');
 
-  });
+});
 
 QUnit.test('combined buffer is the only active buffer when main track enabled',
-  function() {
-    let mediaSource = new videojs.MediaSource();
-    let sourceBufferAudio;
-    let sourceBufferCombined;
-    let audioTracks = [{
-      enabled: true,
-      kind: 'main',
-      label: 'main'
-    }, {
-      enabled: false,
-      kind: 'alternative',
-      label: 'English (UK)'
-    }];
+function() {
+  let mediaSource = new videojs.MediaSource();
+  let sourceBufferAudio;
+  let sourceBufferCombined;
+  let audioTracks = [{
+    enabled: true,
+    kind: 'main',
+    label: 'main'
+  }, {
+    enabled: false,
+    kind: 'alternative',
+    label: 'English (UK)'
+  }];
 
-    this.player.audioTracks = () => audioTracks;
+  this.player.audioTracks = () => audioTracks;
 
-    mediaSource.player_ = this.player;
+  mediaSource.player_ = this.player;
 
-    sourceBufferCombined = mediaSource.addSourceBuffer('video/m2pt');
-    sourceBufferCombined.videoCodec_ = true;
-    sourceBufferCombined.audioCodec_ = true;
-    sourceBufferAudio = mediaSource.addSourceBuffer('video/m2pt');
-    sourceBufferAudio.videoCodec_ = false;
-    sourceBufferAudio.audioCodec_ = true;
+  sourceBufferCombined = mediaSource.addSourceBuffer('video/m2pt');
+  sourceBufferCombined.videoCodec_ = true;
+  sourceBufferCombined.audioCodec_ = true;
+  sourceBufferAudio = mediaSource.addSourceBuffer('video/m2pt');
+  sourceBufferAudio.videoCodec_ = false;
+  sourceBufferAudio.audioCodec_ = true;
 
-    mediaSource.updateActiveSourceBuffers_();
+  mediaSource.updateActiveSourceBuffers_();
 
-    QUnit.equal(mediaSource.activeSourceBuffers.length, 1,
-      'active source buffers starts with one source buffer');
-    QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
-      'active source buffers starts with combined source buffer');
-  });
+  QUnit.equal(mediaSource.activeSourceBuffers.length, 1,
+    'active source buffers starts with one source buffer');
+  QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
+    'active source buffers starts with combined source buffer');
+});
 
 QUnit.test('combined & audio buffers are active when alternative track enabled',
-  function() {
-    let mediaSource = new videojs.MediaSource();
-    let sourceBufferAudio;
-    let sourceBufferCombined;
-    let audioTracks = [{
-      enabled: false,
-      kind: 'main',
-      label: 'main'
-    }, {
-      enabled: true,
-      kind: 'alternative',
-      label: 'English (UK)'
-    }];
+function() {
+  let mediaSource = new videojs.MediaSource();
+  let sourceBufferAudio;
+  let sourceBufferCombined;
+  let audioTracks = [{
+    enabled: false,
+    kind: 'main',
+    label: 'main'
+  }, {
+    enabled: true,
+    kind: 'alternative',
+    label: 'English (UK)'
+  }];
 
-    this.player.audioTracks = () => audioTracks;
+  this.player.audioTracks = () => audioTracks;
 
-    mediaSource.player_ = this.player;
+  mediaSource.player_ = this.player;
 
-    sourceBufferCombined = mediaSource.addSourceBuffer('video/m2pt');
-    sourceBufferCombined.videoCodec_ = true;
-    sourceBufferCombined.audioCodec_ = true;
-    sourceBufferAudio = mediaSource.addSourceBuffer('video/m2pt');
-    sourceBufferAudio.videoCodec_ = false;
-    sourceBufferAudio.audioCodec_ = true;
+  sourceBufferCombined = mediaSource.addSourceBuffer('video/m2pt');
+  sourceBufferCombined.videoCodec_ = true;
+  sourceBufferCombined.audioCodec_ = true;
+  sourceBufferAudio = mediaSource.addSourceBuffer('video/m2pt');
+  sourceBufferAudio.videoCodec_ = false;
+  sourceBufferAudio.audioCodec_ = true;
 
-    mediaSource.updateActiveSourceBuffers_();
+  mediaSource.updateActiveSourceBuffers_();
 
-    QUnit.equal(mediaSource.activeSourceBuffers.length, 2,
-      'active source buffers includes both source buffers');
-    // maintains same order as source buffers were created
-    QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
-      'active source buffers starts with combined source buffer');
-    QUnit.equal(mediaSource.activeSourceBuffers[1], sourceBufferAudio,
-      'active source buffers ends with audio source buffer');
-  });
+  QUnit.equal(mediaSource.activeSourceBuffers.length, 2,
+    'active source buffers includes both source buffers');
+  // maintains same order as source buffers were created
+  QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
+    'active source buffers starts with combined source buffer');
+  QUnit.equal(mediaSource.activeSourceBuffers[1], sourceBufferAudio,
+    'active source buffers ends with audio source buffer');
+});
 
 QUnit.test('video only & audio only buffers are always active',
-  function() {
-    let mediaSource = new videojs.MediaSource();
-    let sourceBufferAudio;
-    let sourceBufferCombined;
-    let audioTracks = [{
-      enabled: false,
-      kind: 'main',
-      label: 'main'
-    }, {
-      enabled: true,
-      kind: 'alternative',
-      label: 'English (UK)'
-    }];
+function() {
+  let mediaSource = new videojs.MediaSource();
+  let sourceBufferAudio;
+  let sourceBufferCombined;
+  let audioTracks = [{
+    enabled: false,
+    kind: 'main',
+    label: 'main'
+  }, {
+    enabled: true,
+    kind: 'alternative',
+    label: 'English (UK)'
+  }];
 
-    this.player.audioTracks = () => audioTracks;
+  this.player.audioTracks = () => audioTracks;
 
-    mediaSource.player_ = this.player;
+  mediaSource.player_ = this.player;
 
-    sourceBufferCombined = mediaSource.addSourceBuffer('video/m2pt');
-    sourceBufferCombined.videoCodec_ = true;
-    sourceBufferCombined.audioCodec_ = false;
-    sourceBufferAudio = mediaSource.addSourceBuffer('video/m2pt');
-    sourceBufferAudio.videoCodec_ = false;
-    sourceBufferAudio.audioCodec_ = true;
+  sourceBufferCombined = mediaSource.addSourceBuffer('video/m2pt');
+  sourceBufferCombined.videoCodec_ = true;
+  sourceBufferCombined.audioCodec_ = false;
+  sourceBufferAudio = mediaSource.addSourceBuffer('video/m2pt');
+  sourceBufferAudio.videoCodec_ = false;
+  sourceBufferAudio.audioCodec_ = true;
 
-    mediaSource.updateActiveSourceBuffers_();
+  mediaSource.updateActiveSourceBuffers_();
 
-    QUnit.equal(mediaSource.activeSourceBuffers.length, 2,
-      'active source buffers includes both source buffers');
-    // maintains same order as source buffers were created
-    QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
-      'active source buffers starts with combined source buffer');
-    QUnit.equal(mediaSource.activeSourceBuffers[1], sourceBufferAudio,
-      'active source buffers ends with audio source buffer');
+  QUnit.equal(mediaSource.activeSourceBuffers.length, 2,
+    'active source buffers includes both source buffers');
+  // maintains same order as source buffers were created
+  QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
+    'active source buffers starts with combined source buffer');
+  QUnit.equal(mediaSource.activeSourceBuffers[1], sourceBufferAudio,
+    'active source buffers ends with audio source buffer');
 
-    audioTracks[0].enabled = true;
-    audioTracks[1].enabled = false;
-    mediaSource.updateActiveSourceBuffers_();
+  audioTracks[0].enabled = true;
+  audioTracks[1].enabled = false;
+  mediaSource.updateActiveSourceBuffers_();
 
-    QUnit.equal(mediaSource.activeSourceBuffers.length, 2,
-      'active source buffers includes both source buffers');
-    // maintains same order as source buffers were created
-    QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
-      'active source buffers starts with combined source buffer');
-    QUnit.equal(mediaSource.activeSourceBuffers[1], sourceBufferAudio,
-      'active source buffers ends with audio source buffer');
+  QUnit.equal(mediaSource.activeSourceBuffers.length, 2,
+    'active source buffers includes both source buffers');
+  // maintains same order as source buffers were created
+  QUnit.equal(mediaSource.activeSourceBuffers[0], sourceBufferCombined,
+    'active source buffers starts with combined source buffer');
+  QUnit.equal(mediaSource.activeSourceBuffers[1], sourceBufferAudio,
+    'active source buffers ends with audio source buffer');
 
-  });
+});
 
 QUnit.test('video segments with info trigger videooinfo event', function() {
   let data = new Uint8Array(1);
   let infoEvents = [];
   let mediaSource = new videojs.MediaSource();
   let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
-  let info = {
-    width: 100
-  };
-  let newinfo = {
-    width: 225
-  };
+  let info = {width: 100};
+  let newinfo = {width: 225};
 
   mediaSource.on('videoinfo', (e) => infoEvents.push(e));
 
   // send an audio segment with info, then send done
-  sourceBuffer.transmuxer_.onmessage(createDataMessage('video', data, {
-    info
-  }));
+  sourceBuffer.transmuxer_.onmessage(createDataMessage('video', data, {info}));
   sourceBuffer.transmuxer_.onmessage(doneMessage);
 
   QUnit.equal(infoEvents.length, 1, 'video info should trigger');
   QUnit.deepEqual(infoEvents[0].info, info, 'video info = muxed info');
 
   // send an audio segment with info, then send done
-  sourceBuffer.transmuxer_.onmessage(createDataMessage('video', data, {
-    info: newinfo
-  }));
+  sourceBuffer.transmuxer_.onmessage(createDataMessage('video', data, {info: newinfo}));
   sourceBuffer.transmuxer_.onmessage(doneMessage);
 
   QUnit.equal(infoEvents.length, 2, 'video info should trigger');
@@ -1019,28 +1002,20 @@ QUnit.test('audio segments with info trigger audioinfo event', function() {
   let infoEvents = [];
   let mediaSource = new videojs.MediaSource();
   let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
-  let info = {
-    width: 100
-  };
-  let newinfo = {
-    width: 225
-  };
+  let info = {width: 100};
+  let newinfo = {width: 225};
 
   mediaSource.on('audioinfo', (e) => infoEvents.push(e));
 
   // send an audio segment with info, then send done
-  sourceBuffer.transmuxer_.onmessage(createDataMessage('audio', data, {
-    info
-  }));
+  sourceBuffer.transmuxer_.onmessage(createDataMessage('audio', data, {info}));
   sourceBuffer.transmuxer_.onmessage(doneMessage);
 
   QUnit.equal(infoEvents.length, 1, 'audio info should trigger');
   QUnit.deepEqual(infoEvents[0].info, info, 'audio info = muxed info');
 
   // send an audio segment with info, then send done
-  sourceBuffer.transmuxer_.onmessage(createDataMessage('audio', data, {
-    info: newinfo
-  }));
+  sourceBuffer.transmuxer_.onmessage(createDataMessage('audio', data, {info: newinfo}));
   sourceBuffer.transmuxer_.onmessage(doneMessage);
 
   QUnit.equal(infoEvents.length, 2, 'audio info should trigger');
@@ -1048,41 +1023,40 @@ QUnit.test('audio segments with info trigger audioinfo event', function() {
 });
 
 QUnit.test('creates native SourceBuffers immediately if a second ' +
-  'VirtualSourceBuffer is created',
-  function() {
-    let mediaSource = new videojs.MediaSource();
-    let sourceBuffer =
-      mediaSource.addSourceBuffer('video/mp2t; codecs="avc1.64001f,mp4a.40.5"');
-    let sourceBuffer2 =
-      mediaSource.addSourceBuffer('video/mp2t; codecs="mp4a.40.5"');
+           'VirtualSourceBuffer is created', function() {
+  let mediaSource = new videojs.MediaSource();
+  let sourceBuffer =
+    mediaSource.addSourceBuffer('video/mp2t; codecs="avc1.64001f,mp4a.40.5"');
+  let sourceBuffer2 =
+    mediaSource.addSourceBuffer('video/mp2t; codecs="mp4a.40.5"');
 
-    QUnit.ok(mediaSource.videoBuffer_, 'created a video buffer');
-    QUnit.equal(
-      mediaSource.videoBuffer_.type,
-      'video/mp4;codecs="avc1.64001f"',
-      'video buffer has the specified codec'
-    );
+  QUnit.ok(mediaSource.videoBuffer_, 'created a video buffer');
+  QUnit.equal(
+    mediaSource.videoBuffer_.type,
+    'video/mp4;codecs="avc1.64001f"',
+    'video buffer has the specified codec'
+  );
 
-    QUnit.ok(mediaSource.audioBuffer_, 'created an audio buffer');
-    QUnit.equal(
-      mediaSource.audioBuffer_.type,
-      'audio/mp4;codecs="mp4a.40.5"',
-      'audio buffer has the specified codec'
-    );
-    QUnit.equal(mediaSource.sourceBuffers.length, 2, 'created two virtual buffers');
-    QUnit.equal(
-      mediaSource.sourceBuffers[0],
-      sourceBuffer,
-      'returned the virtual buffer');
-    QUnit.equal(
-      mediaSource.sourceBuffers[1],
-      sourceBuffer2,
-      'returned the virtual buffer');
-    QUnit.equal(
-      sourceBuffer.audioDisabled_,
-      true,
-      'first source buffer\'s audio is automatically disabled');
-    QUnit.ok(
-      sourceBuffer2.audioBuffer_,
-      'second source buffer has an audio source buffer');
-  });
+  QUnit.ok(mediaSource.audioBuffer_, 'created an audio buffer');
+  QUnit.equal(
+    mediaSource.audioBuffer_.type,
+    'audio/mp4;codecs="mp4a.40.5"',
+    'audio buffer has the specified codec'
+  );
+  QUnit.equal(mediaSource.sourceBuffers.length, 2, 'created two virtual buffers');
+  QUnit.equal(
+    mediaSource.sourceBuffers[0],
+    sourceBuffer,
+    'returned the virtual buffer');
+  QUnit.equal(
+    mediaSource.sourceBuffers[1],
+    sourceBuffer2,
+    'returned the virtual buffer');
+  QUnit.equal(
+    sourceBuffer.audioDisabled_,
+    true,
+    'first source buffer\'s audio is automatically disabled');
+  QUnit.ok(
+    sourceBuffer2.audioBuffer_,
+    'second source buffer has an audio source buffer');
+});

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -786,13 +786,13 @@ QUnit.test('translates metadata events into WebVTT cues', function() {
   QUnit.equal(cues.length, 3, 'created three cues');
   QUnit.equal(cues[0].text, 'This is a url tag', 'included the text');
   QUnit.equal(cues[0].startTime, 12, 'started at twelve');
-  QUnit.equal(cues[0].endTime, Number.MAX_VALUE, 'ended at the duration of the video');
+  QUnit.equal(cues[0].endTime, 12, 'ended at twelve');
   QUnit.equal(cues[1].text, 'This is a text tag', 'included the text');
   QUnit.equal(cues[1].startTime, 12, 'started at twelve');
-  QUnit.equal(cues[1].endTime, Number.MAX_VALUE, 'ended at the duration of the video');
+  QUnit.equal(cues[1].endTime, 12, 'ended at twelve');
   QUnit.equal(cues[2].text, 'This is a priv tag', 'included the text');
   QUnit.equal(cues[2].startTime, 22, 'started at twenty two');
-  QUnit.equal(cues[2].endTime, Number.MAX_VALUE, 'ended at the duration of the video');
+  QUnit.equal(cues[2].endTime, 22, 'ended at twenty two');
 });
 
 QUnit.test('does not wrap mp4 source buffers', function() {


### PR DESCRIPTION
Normalized the ID3 behavior to follow Safari's implementation.
On each segment:
1) Create cues from the id3 tags that start at the proper time and end at the start of the next id3 in time
2) The last cue should have an end time that is very large (MAX_NUMBER)
3) When more id3 tags are loaded, set the end time of any cues that overlap the first id3 tag to end at the start time of the first id3 tags
