### PR TITLE
Disabled source buffers may still have buffered content

### DIFF
--- a/src/html-media-source.js
+++ b/src/html-media-source.js
@@ -238,7 +238,7 @@ export default class HtmlMediaSource extends videojs.EventTarget {
 
     // Create a VirtualSourceBuffer to transmux MPEG-2 transport
     // stream segments into fragmented MP4s
-    if (parsedType.type === 'video/mp2t') {
+    if ((/^(video|audio)\/mp2t$/i).test(parsedType.type)) {
       let codecs = [];
 
       if (parsedType.parameters && parsedType.parameters.codecs) {

--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -115,20 +115,27 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
         let extents = [];
         let ranges = [];
 
-        if (!this.videoBuffer_ && (this.audioDisabled_ || !this.audioBuffer_)) {
+        // neither buffer has been created yet
+        if (!this.videoBuffer_ && !this.audioBuffer_) {
           return videojs.createTimeRange();
         }
 
-        // Handle the case where we only have one buffer
+        // only one buffer is configured
         if (!this.videoBuffer_) {
           return this.audioBuffer_.buffered;
-        } else if (this.audioDisabled_ || !this.audioBuffer_) {
+        }
+        if (!this.audioBuffer_) {
           return this.videoBuffer_.buffered;
         }
 
-        // Handle the case where there is no buffer data
-        if ((!this.videoBuffer_ || this.videoBuffer_.buffered.length === 0) &&
-            (!this.audioBuffer_ || this.audioBuffer_.buffered.length === 0)) {
+        // both buffers are configured
+        if (this.audioDisabled_) {
+          return this.videoBuffer_.buffered;
+        }
+
+        // both buffers are empty
+        if (this.videoBuffer_.buffered.length === 0 &&
+            this.audioBuffer_.buffered.length === 0) {
           return videojs.createTimeRange();
         }
 
@@ -338,7 +345,7 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
     if (this.videoBuffer_) {
       this.videoBuffer_.remove(start, end);
     }
-    if (!this.audioDisabled_ && this.audioBuffer_) {
+    if (this.audioBuffer_) {
       this.audioBuffer_.remove(start, end);
     }
 


### PR DESCRIPTION
Don't hide buffered content in a source buffer with audio disabled because well-behaved clients could misinterpret this. For example, a client may choose not to remove buffered data from a disabled audio source buffer since it appears empty.