### PR TITLE
remove window from transmuxer-worker

### DIFF
--- a/src/transmuxer-worker.js
+++ b/src/transmuxer-worker.js
@@ -12,7 +12,6 @@
  * transmuxer running inside of a WebWorker by exposing a simple
  * message-based interface to a Transmuxer object.
  */
-import window from 'global/window';
 import mp4 from 'mux.js/lib/mp4';
 
 /**
@@ -31,7 +30,7 @@ const wireTransmuxerEvents = function(transmuxer) {
     let typedArray = segment.data;
 
     segment.data = typedArray.buffer;
-    window.postMessage({
+    postMessage({
       action: 'data',
       segment,
       byteOffset: typedArray.byteOffset,
@@ -41,7 +40,7 @@ const wireTransmuxerEvents = function(transmuxer) {
 
   if (transmuxer.captionStream) {
     transmuxer.captionStream.on('data', function(caption) {
-      window.postMessage({
+      postMessage({
         action: 'caption',
         data: caption
       });
@@ -49,7 +48,7 @@ const wireTransmuxerEvents = function(transmuxer) {
   }
 
   transmuxer.on('done', function(data) {
-    window.postMessage({ action: 'done' });
+    postMessage({ action: 'done' });
   });
 };
 


### PR DESCRIPTION
If you use video.js+videojs-contrib-hls and build them using webpack, than need to use webworkify-webpack package.
webworkify-webpack make global variable window = {} for workers.
And src/transmuxer-worker.js used window.postMessage..
So, in this case it does not work with the error window.postMessage is not a function.
But window variable not needed in workers, and if delete it - all work correctly.