### PR TITLE
Only trim FLV tags when seeking to prevent triming I frames

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   ],
   "dependencies": {
     "global": "^4.3.0",
-    "mux.js": "^3.0.0",
+    "mux.js": "^3.0.2",
     "video.js": "^5.10.1",
     "webworkify": "1.0.2"
   },

--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -348,13 +348,10 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
       this.basePtsOffset_ = tags[0].pts;
     }
 
-    // Trim any tags that are before the end of the end of
-    // the current buffer
-    if (tech.buffered().length) {
-      targetPts = tech.buffered().end(0) - this.timestampOffset;
-    }
     // Trim to currentTime if it's ahead of buffered or buffered doesn't exist
-    targetPts = Math.max(targetPts, tech.currentTime() - this.timestampOffset);
+    if (tech.seeking()) {
+      targetPts = Math.max(targetPts, tech.currentTime() - this.timestampOffset);
+    }
 
     // PTS values are represented in milliseconds
     targetPts *= 1e3;

--- a/test/flash.test.js
+++ b/test/flash.test.js
@@ -410,53 +410,6 @@ QUnit.test('drops tags before currentTime when seeking', function() {
             'three tags are appended');
 });
 
-QUnit.test('drops tags before the buffered end always', function() {
-  let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
-  let i = 10;
-  let endTime;
-  let tags_ = [];
-
-  this.mediaSource.tech_.buffered = function() {
-    return videojs.createTimeRange([[0, endTime]]);
-  };
-
-  // push a tag into the buffer to establish the starting PTS value
-  endTime = 0;
-  sourceBuffer.segmentParser_.trigger('data', {
-    tags: {
-      videoTags: [makeFlvTag(19 * 1000, new Uint8Array(1))],
-      audioTags: []
-    }
-  });
-  timers.runAll();
-
-  sourceBuffer.appendBuffer(new Uint8Array(10));
-  timers.runAll();
-
-  // mock out a new segment of FLV tags, starting 10s after the
-  // starting PTS value
-  while (i--) {
-    tags_.unshift(
-      makeFlvTag((i * 1000) + (29 * 1000),
-        new Uint8Array([i])));
-  }
-  sourceBuffer.segmentParser_.trigger('data', {
-    tags: {
-      videoTags: tags_,
-      audioTags: []
-    }
-  });
-
-  endTime = 10 + 7;
-  this.mediaSource.tech_.trigger('seeking');
-  sourceBuffer.appendBuffer(new Uint8Array(10));
-  this.swfCalls.length = 0;
-  timers.runAll();
-
-  QUnit.deepEqual(this.swfCalls[0].arguments[0], [7, 8, 9],
-            'three tags are appended');
-});
-
 QUnit.test('seek targeting accounts for changing timestampOffsets', function() {
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
   let i = 10;


### PR DESCRIPTION
The flash source buffer trims any FLV tags that are before the end of the current buffer to prevent overlapping or misalignment on appends. This was causing some I frames to be trimmed in some streams, which would create blocky artifacts during playback.

This change removes the trimming of tags before the end of the current buffer and also uses the tech's seeking property to determine when a seek happens instead of inferring a seek based on the state of the buffer. 