### PR TITLE
append init segment to video buffer for every segment

### DIFF
--- a/src/html-media-source.js
+++ b/src/html-media-source.js
@@ -132,7 +132,7 @@ export default class HtmlMediaSource extends videojs.EventTarget {
         //      what stream is the video stream, rather than relying on videoTracks
         /* eslinst-enable */
 
-        sourceBuffer.appendInitSegment_ = true;
+        sourceBuffer.appendAudioInitSegment_ = true;
 
         if (sourceBuffer.videoCodec_ && sourceBuffer.audioCodec_) {
           // combined
@@ -157,7 +157,7 @@ export default class HtmlMediaSource extends videojs.EventTarget {
 
     this.onPlayerMediachange_ = () => {
       this.sourceBuffers.forEach((sourceBuffer) => {
-        sourceBuffer.appendInitSegment_ = true;
+        sourceBuffer.appendAudioInitSegment_ = true;
       });
     };
 

--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -33,7 +33,7 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
     this.audioCodec_ = null;
     this.videoCodec_ = null;
     this.audioDisabled_ = false;
-    this.appendInitSegment_ = true;
+    this.appendAudioInitSegment_ = true;
 
     let options = {
       remux: false
@@ -71,7 +71,7 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
       set(val) {
         if (typeof val === 'number' && val >= 0) {
           this.timestampOffset_ = val;
-          this.appendInitSegment_ = true;
+          this.appendAudioInitSegment_ = true;
 
           // We have to tell the transmuxer to set the baseMediaDecodeTime to
           // the desired timestampOffset for the next segment
@@ -436,12 +436,12 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
       this.mediaSource_.trigger({type: 'videoinfo', info: sortedSegments.video.info});
     }
 
-    if (this.appendInitSegment_) {
+    if (this.appendAudioInitSegment_) {
       if (!this.audioDisabled_ && this.audioBuffer_) {
         sortedSegments.audio.segments.unshift(sortedSegments.audio.initSegment);
         sortedSegments.audio.bytes += sortedSegments.audio.initSegment.byteLength;
       }
-      this.appendInitSegment_ = false;
+      this.appendAudioInitSegment_ = false;
     }
 
     // Merge multiple video and audio segments into one and append

--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -437,10 +437,6 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
     }
 
     if (this.appendInitSegment_) {
-      if (this.videoBuffer_) {
-        sortedSegments.video.segments.unshift(sortedSegments.video.initSegment);
-        sortedSegments.video.bytes += sortedSegments.video.initSegment.byteLength;
-      }
       if (!this.audioDisabled_ && this.audioBuffer_) {
         sortedSegments.audio.segments.unshift(sortedSegments.audio.initSegment);
         sortedSegments.audio.bytes += sortedSegments.audio.initSegment.byteLength;
@@ -450,6 +446,8 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
 
     // Merge multiple video and audio segments into one and append
     if (this.videoBuffer_) {
+      sortedSegments.video.segments.unshift(sortedSegments.video.initSegment);
+      sortedSegments.video.bytes += sortedSegments.video.initSegment.byteLength;
       this.concatAndAppendSegments_(sortedSegments.video, this.videoBuffer_);
       // TODO: are video tracks the only ones with text tracks?
       addTextTrackData(this, sortedSegments.captions, sortedSegments.metadata);

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -444,7 +444,7 @@ function() {
 });
 
 QUnit.test(
-'only appends init segment for first segment or on audio/media changes',
+'only appends audio init segment for first segment or on audio/media changes',
 function() {
   let mp4Segments = [];
   let initBuffer = new Uint8Array([0, 1]);
@@ -466,7 +466,7 @@ function() {
     mp4Segments.push(segment);
   };
 
-  QUnit.ok(sourceBuffer.appendInitSegment_, 'will append init segment next');
+  QUnit.ok(sourceBuffer.appendAudioInitSegment_, 'will append init segment next');
 
   // an init segment
   sourceBuffer.transmuxer_.onmessage(createDataMessage('audio', dataBuffer, {
@@ -494,7 +494,7 @@ function() {
   QUnit.equal(mp4Segments[0][1], 1, 'fragment contains the correct second byte');
   QUnit.equal(mp4Segments[0][2], 2, 'fragment contains the correct third byte');
   QUnit.equal(mp4Segments[0][3], 3, 'fragment contains the correct fourth byte');
-  QUnit.ok(!sourceBuffer.appendInitSegment_, 'will not append init segment next');
+  QUnit.ok(!sourceBuffer.appendAudioInitSegment_, 'will not append init segment next');
 
   dataBuffer = new Uint8Array([4, 5]);
   sourceBuffer.transmuxer_.onmessage(createDataMessage('audio', dataBuffer, {
@@ -513,7 +513,7 @@ function() {
   // audio track change
   this.player.audioTracks().trigger('change');
   sourceBuffer.audioDisabled_ = false;
-  QUnit.ok(sourceBuffer.appendInitSegment_, 'audio change sets appendInitSegment_');
+  QUnit.ok(sourceBuffer.appendAudioInitSegment_, 'audio change sets appendAudioInitSegment_');
   dataBuffer = new Uint8Array([6, 7]);
   sourceBuffer.transmuxer_.onmessage(createDataMessage('audio', dataBuffer, {
     initSegment: {
@@ -529,7 +529,7 @@ function() {
   QUnit.equal(mp4Segments[2][1], 1, 'fragment contains the correct second byte');
   QUnit.equal(mp4Segments[2][2], 6, 'fragment contains the correct third byte');
   QUnit.equal(mp4Segments[2][3], 7, 'fragment contains the correct fourth byte');
-  QUnit.ok(!sourceBuffer.appendInitSegment_, 'will not append init segment next');
+  QUnit.ok(!sourceBuffer.appendAudioInitSegment_, 'will not append init segment next');
 
   dataBuffer = new Uint8Array([8, 9]);
   sourceBuffer.transmuxer_.onmessage(createDataMessage('audio', dataBuffer, {
@@ -544,11 +544,11 @@ function() {
   // does not contain init segment in next segment
   QUnit.equal(mp4Segments[3][0], 8, 'fragment contains the correct first byte');
   QUnit.equal(mp4Segments[3][1], 9, 'fragment contains the correct second byte');
-  QUnit.ok(!sourceBuffer.appendInitSegment_, 'will not append init segment next');
+  QUnit.ok(!sourceBuffer.appendAudioInitSegment_, 'will not append init segment next');
 
   // rendition switch
   this.player.trigger('mediachange');
-  QUnit.ok(sourceBuffer.appendInitSegment_, 'media change sets appendInitSegment_');
+  QUnit.ok(sourceBuffer.appendAudioInitSegment_, 'media change sets appendAudioInitSegment_');
   dataBuffer = new Uint8Array([10, 11]);
   sourceBuffer.transmuxer_.onmessage(createDataMessage('audio', dataBuffer, {
     initSegment: {
@@ -564,7 +564,88 @@ function() {
   QUnit.equal(mp4Segments[4][1], 1, 'fragment contains the correct second byte');
   QUnit.equal(mp4Segments[4][2], 10, 'fragment contains the correct third byte');
   QUnit.equal(mp4Segments[4][3], 11, 'fragment contains the correct fourth byte');
-  QUnit.ok(!sourceBuffer.appendInitSegment_, 'will not append init segment next');
+  QUnit.ok(!sourceBuffer.appendAudioInitSegment_, 'will not append init segment next');
+});
+
+QUnit.test(
+'appends video init segment for every segment',
+function() {
+  let mp4Segments = [];
+  let initBuffer = new Uint8Array([0, 1]);
+  let dataBuffer = new Uint8Array([2, 3]);
+  let mediaSource;
+  let sourceBuffer;
+
+  mediaSource = new videojs.MediaSource();
+  sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+  mediaSource.player_ = this.player;
+  mediaSource.url_ = this.url;
+  mediaSource.trigger('sourceopen');
+
+  sourceBuffer.concatAndAppendSegments_ = function(segmentObj, destinationBuffer) {
+    let segment = segmentObj.segments.reduce((seg, arr) => seg.concat(Array.from(arr)),
+      []);
+
+    mp4Segments.push(segment);
+  };
+
+  // an init segment
+  sourceBuffer.transmuxer_.onmessage(createDataMessage('video', dataBuffer, {
+    initSegment: {
+      data: initBuffer.buffer,
+      byteOffset: initBuffer.byteOffset,
+      byteLength: initBuffer.byteLength
+    }
+  }));
+
+  // Segments are concatenated
+  QUnit.equal(
+    mp4Segments.length,
+    0,
+    'segments are not appended until after the `done` message'
+  );
+
+  // send `done` message
+  sourceBuffer.transmuxer_.onmessage(doneMessage);
+
+  // Segments are concatenated
+  QUnit.equal(mp4Segments.length, 1, 'emitted the fragment');
+  // Contains init segment on first segment
+  QUnit.equal(mp4Segments[0][0], 0, 'fragment contains the correct first byte');
+  QUnit.equal(mp4Segments[0][1], 1, 'fragment contains the correct second byte');
+  QUnit.equal(mp4Segments[0][2], 2, 'fragment contains the correct third byte');
+  QUnit.equal(mp4Segments[0][3], 3, 'fragment contains the correct fourth byte');
+
+  dataBuffer = new Uint8Array([4, 5]);
+  sourceBuffer.transmuxer_.onmessage(createDataMessage('video', dataBuffer, {
+    initSegment: {
+      data: initBuffer.buffer,
+      byteOffset: initBuffer.byteOffset,
+      byteLength: initBuffer.byteLength
+    }
+  }));
+  sourceBuffer.transmuxer_.onmessage(doneMessage);
+  QUnit.equal(mp4Segments.length, 2, 'emitted the fragment');
+  QUnit.equal(mp4Segments[1][0], 0, 'fragment contains the correct first byte');
+  QUnit.equal(mp4Segments[1][1], 1, 'fragment contains the correct second byte');
+  QUnit.equal(mp4Segments[1][2], 4, 'fragment contains the correct third byte');
+  QUnit.equal(mp4Segments[1][3], 5, 'fragment contains the correct fourth byte');
+
+  dataBuffer = new Uint8Array([6, 7]);
+  sourceBuffer.transmuxer_.onmessage(createDataMessage('video', dataBuffer, {
+    initSegment: {
+      data: initBuffer.buffer,
+      byteOffset: initBuffer.byteOffset,
+      byteLength: initBuffer.byteLength
+    }
+  }));
+  sourceBuffer.transmuxer_.onmessage(doneMessage);
+  QUnit.equal(mp4Segments.length, 3, 'emitted the fragment');
+  // contains init segment after audio track change
+  QUnit.equal(mp4Segments[2][0], 0, 'fragment contains the correct first byte');
+  QUnit.equal(mp4Segments[2][1], 1, 'fragment contains the correct second byte');
+  QUnit.equal(mp4Segments[2][2], 6, 'fragment contains the correct third byte');
+  QUnit.equal(mp4Segments[2][3], 7, 'fragment contains the correct fourth byte');
 });
 
 QUnit.test('handles empty codec string value', function() {


### PR DESCRIPTION
Some content may be less than ideal and change the video info on segment boundaries in the same rendition. In firefox, this causes rendering issues (green artifacts) since the init segment should change on a video info change.

This change will append an init segment to the video buffer every segment, but still only append init segments for audio on media or audio info change to prevent the audio pop experienced in firefox on segment boundaries.