### PR TITLE
Metadata cues may have length zero

### DIFF
--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -93,11 +93,12 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
       }, this);
     }, sourceHandler);
 
-    /** Updating the metadeta cues so that
-     * the endTime of each cue is the startTime of the next cue
-     * the endTime of last cue is the duration of the video
-     */
-    if (sourceHandler.metadataTrack_ && sourceHandler.metadataTrack_.cues) {
+    // Updating the metadeta cues so that
+    // the endTime of each cue is the startTime of the next cue
+    // the endTime of last cue is the duration of the video
+    if (sourceHandler.metadataTrack_ &&
+        sourceHandler.metadataTrack_.cues &&
+        sourceHandler.metadataTrack_.cues.length) {
       let cues = sourceHandler.metadataTrack_.cues;
       let cuesArray = [];
 

--- a/src/html-media-source.js
+++ b/src/html-media-source.js
@@ -198,7 +198,7 @@ export default class HtmlMediaSource extends videojs.EventTarget {
         let sourcebuffer = this.sourceBuffers[i];
         let cues = sourcebuffer.metadataTrack_ && sourcebuffer.metadataTrack_.cues;
 
-        if (cues) {
+        if (cues && cues.length) {
           cues[cues.length - 1].endTime = duration;
         }
       }

--- a/test/add-text-track-data.test.js
+++ b/test/add-text-track-data.test.js
@@ -1,0 +1,51 @@
+import Qunit from 'qunit';
+import { addTextTrackData } from '../src/add-text-track-data';
+
+const { equal, module, test } = Qunit;
+
+class MockTextTrack {
+  constructor() {
+    this.cues = [];
+  }
+  addCue(cue) {
+    this.cues.push(cue);
+  }
+}
+
+module('Text Track Data', {
+  beforeEach() {
+    this.sourceHandler = {
+      inbandTextTrack_: new MockTextTrack(),
+      metadataTrack_: new MockTextTrack(),
+      mediaSource_: {
+        duration: NaN
+      },
+      timestampOffset: 0
+    };
+  }
+});
+
+test('does nothing if no cues are specified', function() {
+  addTextTrackData(this.sourceHandler, [], []);
+  equal(this.sourceHandler.inbandTextTrack_.cues.length, 0, 'added no 608 cues');
+  equal(this.sourceHandler.metadataTrack_.cues.length, 0, 'added no metadata cues');
+});
+
+test('creates cues for 608 captions', function() {
+  addTextTrackData(this.sourceHandler, [{
+    startTime: 0,
+    endTime: 1,
+    text: 'caption text'
+  }], []);
+  equal(this.sourceHandler.inbandTextTrack_.cues.length, 1, 'added one 608 cues');
+  equal(this.sourceHandler.metadataTrack_.cues.length, 0, 'added no metadata cues');
+});
+
+test('creates cues for timed metadata', function() {
+  addTextTrackData(this.sourceHandler, [], [{
+    cueTime: 1,
+    frames: [{}]
+  }]);
+  equal(this.sourceHandler.inbandTextTrack_.cues.length, 0, 'added no 608 cues');
+  equal(this.sourceHandler.metadataTrack_.cues.length, 1, 'added one metadata cues');
+});


### PR DESCRIPTION
It's not safe to assume that there is at least one element in metadata cues when addTextTrackData() is invoked. Double check the array is there and non-empty before tweaking start and end times. Add tests for that module.