### PR TITLE
catch error on appendbuffer

### DIFF
--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -483,7 +483,16 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
         offset += segment.byteLength;
       });
 
-      destinationBuffer.appendBuffer(tempBuffer);
+      try {
+        destinationBuffer.appendBuffer(tempBuffer);
+      } catch (error) {
+        if (this.mediaSource_.player_) {
+          this.mediaSource_.player_.error({
+            code: -3,
+            type: 'APPEND_BUFFER_ERR'
+          });
+        }
+      }
     }
   }
 

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -351,9 +351,12 @@ QUnit.test('appendBuffer error triggers on the player', function() {
 
   this.player.on('error', () => error = true);
 
-  // A second call to this acts as an append, since the appendBuffer we are testing is
-  // the native one, we need to skip past the virtual source buffer's appendBuffer
-  initializeNativeSourceBuffers(sourceBuffer);
+  // send fake data to the source buffer from the transmuxer to append to native buffer
+  // initializeNativeSourceBuffers does the same thing to trigger the creation of
+  // native source buffers.
+  let fakeTransmuxerMessage = initializeNativeSourceBuffers;
+
+  fakeTransmuxerMessage(sourceBuffer);
 
   this.clock.tick(1);
 

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -336,6 +336,30 @@ QUnit.test('addSeekableRange_ adds to the native MediaSource duration', function
   QUnit.equal(mediaSource.duration, Infinity, 'emulated duration');
 });
 
+QUnit.test('appendBuffer error triggers on the player', function() {
+  let mediaSource = new videojs.MediaSource();
+  let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+  let error = false;
+
+  mediaSource.player_ = this.player;
+
+  initializeNativeSourceBuffers(sourceBuffer);
+
+  sourceBuffer.videoBuffer_.appendBuffer = () => {
+    throw new Error();
+  };
+
+  this.player.on('error', () => error = true);
+
+  // A second call to this acts as an append, since the appendBuffer we are testing is
+  // the native one, we need to skip past the virtual source buffer's appendBuffer
+  initializeNativeSourceBuffers(sourceBuffer);
+
+  this.clock.tick(1);
+
+  QUnit.ok(error, 'error triggered on player');
+});
+
 QUnit.test('transmuxes mp2t segments', function() {
   let mp2tSegments = [];
   let mp4Segments = [];


### PR DESCRIPTION
appendBuffer can throw a QuotaExceededError. This would cause the player to fail without videojs reporting any errors. This will report the error to the player so the error actually gets reported.