### PR TITLE
Start using remote TextTracks because they can be properly removed

### DIFF
--- a/src/cleanup-text-tracks.js
+++ b/src/cleanup-text-tracks.js
@@ -1,0 +1,31 @@
+/**
+ * Remove the text track from the player if one with matching kind and
+ * label properties already exists on the player
+ *
+ * @param {Object} player the video.js player object
+ * @param {String} kind to be considered the text track's `kind` must match
+ * @param {String} label to be considered the text track's `label` must match
+ * @private
+ */
+export const removeExistingTrack = function(player, kind, label) {
+  const tracks = player.remoteTextTracks() || [];
+
+  for (let i = 0; i < tracks.length; i++) {
+    const track = tracks[i];
+
+    if (track.kind === kind && track.label === label) {
+      player.removeRemoteTextTrack(track);
+    }
+  }
+};
+
+/**
+ * Cleaup text tracks on video.js if they exist
+ *
+ * @param {Object} player the video.js player object
+ * @private
+ */
+export const cleanupTextTracks = function(player) {
+  removeExistingTrack(player, 'captions', 'cc1');
+  removeExistingTrack(player, 'metadata', 'Timed Metadata');
+};

--- a/src/create-text-tracks-if-necessary.js
+++ b/src/create-text-tracks-if-necessary.js
@@ -1,6 +1,7 @@
 /**
  * @file create-text-tracks-if-necessary.js
  */
+import {removeExistingTrack} from './cleanup-text-tracks';
 
 /**
  * Create text tracks on video.js if they exist on a segment.
@@ -11,18 +12,27 @@
  * @private
  */
 const createTextTracksIfNecessary = function(sourceBuffer, mediaSource, segment) {
+  const player = mediaSource.player_;
+
   // create an in-band caption track if one is present in the segment
   if (segment.captions &&
       segment.captions.length &&
       !sourceBuffer.inbandTextTrack_) {
-    sourceBuffer.inbandTextTrack_ = mediaSource.player_.addTextTrack('captions', 'cc1');
+    removeExistingTrack(player, 'captions', 'cc1');
+    sourceBuffer.inbandTextTrack_ = player.addRemoteTextTrack({
+      kind: 'captions',
+      label: 'cc1'
+    }, false).track;
   }
 
   if (segment.metadata &&
       segment.metadata.length &&
       !sourceBuffer.metadataTrack_) {
-    sourceBuffer.metadataTrack_ =
-      mediaSource.player_.addTextTrack('metadata', 'Timed Metadata');
+    removeExistingTrack(player, 'metadata', 'Timed Metadata', true);
+    sourceBuffer.metadataTrack_ = player.addRemoteTextTrack({
+      kind: 'metadata',
+      label: 'Timed Metadata'
+    }, false).track;
     sourceBuffer.metadataTrack_.inBandMetadataTrackDispatchType =
       segment.metadata.dispatchType;
   }

--- a/src/flash-media-source.js
+++ b/src/flash-media-source.js
@@ -6,6 +6,7 @@ import videojs from 'video.js';
 import FlashSourceBuffer from './flash-source-buffer';
 import FlashConstants from './flash-constants';
 import {parseContentType} from './codec-utils';
+import {cleanupTextTracks} from './cleanup-text-tracks';
 
 /**
  * A flash implmentation of HTML MediaSources and a polyfill
@@ -35,6 +36,12 @@ export default class FlashMediaSource extends videojs.EventTarget {
           this.sourceBuffers[i].abort();
         }
       });
+
+      if (this.tech_.hls) {
+        this.tech_.hls.on('dispose', () => {
+          cleanupTextTracks(this.player_);
+        });
+      }
 
       // trigger load events
       if (this.swfObj) {

--- a/test/flash.test.js
+++ b/test/flash.test.js
@@ -783,7 +783,7 @@ QUnit.test('cleans up WebVTT cues on hls dispose', function() {
       return addedTracks;
     },
     removeRemoteTextTrack(track) {
-      removedTracks.push(track.kind);
+      removedTracks.push(track);
     }
   };
 
@@ -797,7 +797,15 @@ QUnit.test('cleans up WebVTT cues on hls dispose', function() {
   });
   sourceBuffer.segmentParser_.trigger('done');
 
-  QUnit.equal(addedTracks.length, 2, 'created two remote TextTracks');
+  QUnit.equal(addedTracks.length, 2, 'created two text tracks');
+  QUnit.equal(addedTracks.filter(t => ['captions', 'metadata'].indexOf(t.kind) === -1).length,
+              0,
+              'created only the expected two remote TextTracks');
+
   this.player.tech_.hls.trigger('dispose');
-  QUnit.equal(removedTracks.length, 2, 'removed both TextTracks');
+
+  QUnit.equal(removedTracks.length, 2, 'removed two text tracks');
+  QUnit.equal(removedTracks.filter(t => ['captions', 'metadata'].indexOf(t.kind) === -1).length,
+              0,
+              'removed only the expected two remote TextTracks');
 });

--- a/test/flash.test.js
+++ b/test/flash.test.js
@@ -145,6 +145,7 @@ QUnit.module('Flash MediaSource', {
     swfObj = document.createElement('fake-object');
     swfObj.id = 'fake-swf-' + assert.test.testId;
     this.player.el().replaceChild(swfObj, this.player.tech_.el());
+    this.player.tech_.hls = new videojs.EventTarget();
     this.player.tech_.el_ = swfObj;
     swfObj.tech = this.player.tech_;
     swfObj.CallFunction = (xml) => {
@@ -738,4 +739,65 @@ QUnit.test('fires loadedmetadata after first segment append', function() {
   sourceBuffer.appendBuffer(new Uint8Array([0, 1]));
   timers.runAll();
   QUnit.equal(loadedmetadataCount, 1, 'loadedmetadata does not fire after second append');
+});
+
+QUnit.test('cleans up WebVTT cues on hls dispose', function() {
+  let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
+
+  let addedTracks = [];
+  let removedTracks = [];
+  let metadata = [{
+    cueTime: 2,
+    frames: [{
+      url: 'This is a url tag'
+    }, {
+      value: 'This is a text tag'
+    }]
+  }, {
+    cueTime: 12,
+    frames: [{
+      data: 'This is a priv tag'
+    }]
+  }];
+  let captions = [{
+    startTime: 1,
+    endTime: 3,
+    text: 'This is an in-band caption'
+  }];
+
+  metadata.dispatchType = 0x10;
+  this.mediaSource.player_ = {
+    addRemoteTextTrack(options) {
+      let trackEl = {
+        track: {
+          kind: options.kind,
+          label: options.label,
+          addCue(cue) {}
+        }
+      };
+
+      addedTracks.push(trackEl.track);
+      return trackEl;
+    },
+    remoteTextTracks() {
+      return addedTracks;
+    },
+    removeRemoteTextTrack(track) {
+      removedTracks.push(track.kind);
+    }
+  };
+
+  sourceBuffer.segmentParser_.trigger('data', {
+    tags: {
+      videoTags: [],
+      audioTags: []
+    },
+    metadata,
+    captions
+  });
+  sourceBuffer.segmentParser_.trigger('done');
+
+  QUnit.equal(addedTracks.length, 2, 'created two remote TextTracks');
+  this.player.tech_.hls.trigger('dispose');
+  QUnit.equal(removedTracks.length, 2, 'removed both TextTracks');
 });

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -978,16 +978,22 @@ QUnit.test('translates caption events into WebVTT cues', function() {
   let mediaSource = new videojs.MediaSource();
   let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
   let types = [];
-  let cues = [];
 
   mediaSource.player_ = {
-    addTextTrack(type) {
-      types.push(type);
+    addRemoteTextTrack(options) {
+      types.push(options.kind);
       return {
-        addCue(cue) {
-          cues.push(cue);
+        track: {
+          kind: options.kind,
+          label: options.label,
+          cues: [],
+          addCue(cue) {
+            this.cues.push(cue);
+          }
         }
       };
+    },
+    remoteTextTracks() {
     }
   };
   sourceBuffer.timestampOffset = 10;
@@ -999,6 +1005,7 @@ QUnit.test('translates caption events into WebVTT cues', function() {
     }]
   }));
   sourceBuffer.transmuxer_.onmessage(doneMessage);
+  let cues = sourceBuffer.inbandTextTrack_.cues;
 
   QUnit.equal(types.length, 1, 'created one text track');
   QUnit.equal(types[0], 'captions', 'the type was captions');
@@ -1032,14 +1039,20 @@ QUnit.test('translates metadata events into WebVTT cues', function() {
 
   metadata.dispatchType = 0x10;
   mediaSource.player_ = {
-    addTextTrack(type) {
-      types.push(type);
+    addRemoteTextTrack(options) {
+      types.push(options.kind);
       return {
-        cues: [],
-        addCue(cue) {
-          this.cues.push(cue);
+        track: {
+          kind: options.kind,
+          label: options.label,
+          cues: [],
+          addCue(cue) {
+            this.cues.push(cue);
+          }
         }
       };
+    },
+    remoteTextTracks() {
     }
   };
   sourceBuffer.timestampOffset = 10;

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -1086,6 +1086,79 @@ QUnit.test('translates metadata events into WebVTT cues', function() {
   QUnit.equal(cues[2].endTime, mediaSource.duration, 'sourceended is fired');
 });
 
+QUnit.test('removes existing metadata and caption tracks that exist on the player', function() {
+  let mediaSource = new videojs.MediaSource();
+  let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+
+  mediaSource.duration = Infinity;
+  mediaSource.nativeMediaSource_.duration = 60;
+
+  let addedTracks = [{
+    kind: 'metadata',
+    label: 'Timed Metadata'
+  }, {
+    kind: 'captions',
+    label: 'cc1'
+  }];
+  let removedTracks = [];
+  let metadata = [{
+    cueTime: 2,
+    frames: [{
+      url: 'This is a url tag'
+    }, {
+      value: 'This is a text tag'
+    }]
+  }, {
+    cueTime: 12,
+    frames: [{
+      data: 'This is a priv tag'
+    }]
+  }];
+
+  metadata.dispatchType = 0x10;
+  mediaSource.player_ = {
+    addRemoteTextTrack(options) {
+      let trackEl = {
+        track: {
+          kind: options.kind,
+          label: options.label,
+          addCue(cue) {}
+        }
+      };
+
+      addedTracks.push(trackEl.track);
+      return trackEl;
+    },
+    remoteTextTracks() {
+      return addedTracks;
+    },
+    removeRemoteTextTrack(track) {
+      removedTracks.push(track);
+      addedTracks.splice(addedTracks.indexOf(track), 1);
+    }
+  };
+
+  sourceBuffer.transmuxer_.onmessage(createDataMessage('video', new Uint8Array(1), {
+    metadata,
+    captions: [{
+      startTime: 1,
+      endTime: 3,
+      text: 'This is an in-band caption'
+    }]
+  }));
+  sourceBuffer.transmuxer_.onmessage(doneMessage);
+
+  QUnit.equal(removedTracks.length, 2, 'removed two text tracks');
+  QUnit.equal(removedTracks.filter(t => ['captions', 'metadata'].indexOf(t.kind) === -1).length,
+              0,
+              'removed only the expected two remote TextTracks');
+
+  QUnit.equal(addedTracks.length, 2, 'created two text tracks');
+  QUnit.equal(addedTracks.filter(t => ['captions', 'metadata'].indexOf(t.kind) === -1).length,
+              0,
+              'created only the expected two remote TextTracks');
+});
+
 QUnit.test('cleans up WebVTT cues on sourceclose', function() {
   let mediaSource = new videojs.MediaSource();
   let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
@@ -1127,15 +1200,12 @@ QUnit.test('cleans up WebVTT cues on sourceclose', function() {
       return addedTracks;
     },
     removeRemoteTextTrack(track) {
-      removedTracks.push(track.kind);
+      removedTracks.push(track);
     }
   };
-  sourceBuffer.timestampOffset = 10;
 
   sourceBuffer.transmuxer_.onmessage(createDataMessage('video', new Uint8Array(1), {
-    metadata
-  }));
-  sourceBuffer.transmuxer_.onmessage(createDataMessage('video', new Uint8Array(1), {
+    metadata,
     captions: [{
       startTime: 1,
       endTime: 3,
@@ -1144,9 +1214,17 @@ QUnit.test('cleans up WebVTT cues on sourceclose', function() {
   }));
   sourceBuffer.transmuxer_.onmessage(doneMessage);
 
-  QUnit.equal(addedTracks.length, 2, 'created two remote TextTracks');
+  QUnit.equal(addedTracks.length, 2, 'created two text tracks');
+  QUnit.equal(addedTracks.filter(t => ['captions', 'metadata'].indexOf(t.kind) === -1).length,
+              0,
+              'created only the expected two remote TextTracks');
+
   mediaSource.trigger('sourceclose');
-  QUnit.equal(removedTracks.length, 2, 'removed both TextTracks');
+
+  QUnit.equal(removedTracks.length, 2, 'removed two text tracks');
+  QUnit.equal(removedTracks.filter(t => ['captions', 'metadata'].indexOf(t.kind) === -1).length,
+              0,
+              'removed only the expected two remote TextTracks');
 });
 
 QUnit.test('does not wrap mp4 source buffers', function() {


### PR DESCRIPTION
We were using `videojs.addTextTrack` which creates `TextTrack` objects in memory and associates them with a video element. These are not removable from the video element once added. This PR switches to `videojs.addRemoteTextTrack`and then carefully removes them whenever the MediaSource is closed (in the Html5 case) or the HLS sourceHandler is disposed of (in the Flash case).