### PR TITLE
Don't crash if the initSegment isn't available.

### DIFF
--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -446,8 +446,10 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
 
     // Merge multiple video and audio segments into one and append
     if (this.videoBuffer_) {
-      sortedSegments.video.segments.unshift(sortedSegments.video.initSegment);
-      sortedSegments.video.bytes += sortedSegments.video.initSegment.byteLength;
+      if (sortedSegments.video.initSegment) {
+        sortedSegments.video.segments.unshift(sortedSegments.video.initSegment);
+        sortedSegments.video.bytes += sortedSegments.video.initSegment.byteLength;
+      }
       this.concatAndAppendSegments_(sortedSegments.video, this.videoBuffer_);
       // TODO: are video tracks the only ones with text tracks?
       addTextTrackData(this, sortedSegments.captions, sortedSegments.metadata);


### PR DESCRIPTION
This can happen when using the HLS plugin and we switch from one stream to another due to fluctuations in available bandwidth.