### PR TITLE
Fixed metadata cue mapping so that it considers groups cues with the same startTime and remaps them collectively to the same endTime

### DIFF
--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -127,7 +127,7 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
       // Map each cue group's endTime to the next group's startTime
       sortedStartTimes.forEach((startTime, idx) => {
         let cueGroup = cuesGroupedByStartTime[startTime];
-        let nextTime = sortedStartTimes[idx + 1] || videoDuration;
+        let nextTime = Number(sortedStartTimes[idx + 1]) || videoDuration;
 
         // Map each cue's endTime the next group's startTime
         cueGroup.forEach((cue) => {

--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -102,17 +102,38 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
       let cues = sourceHandler.metadataTrack_.cues;
       let cuesArray = [];
 
-      for (let j = 0; j < cues.length; j++) {
-        cuesArray.push(cues[j]);
-      }
-      cuesArray.sort((first, second) => first.startTime - second.startTime);
-
-      for (let i = 0; i < cuesArray.length - 1; i++) {
-        if (cuesArray[i].endTime !== cuesArray[i + 1].startTime) {
-          cuesArray[i].endTime = cuesArray[i + 1].startTime;
+      // Create a copy of the TextTrackCueList...
+      // ...disregarding cues with a falsey value
+      for (let i = 0; i < cues.length; i++) {
+        if (cues[i]) {
+          cuesArray.push(cues[i]);
         }
       }
-      cuesArray[cuesArray.length - 1].endTime = videoDuration;
+
+      // Group cues by their startTime value
+      let cuesGroupedByStartTime = cuesArray.reduce((obj, cue) => {
+        let timeSlot = obj[cue.startTime] || [];
+
+        timeSlot.push(cue);
+        obj[cue.startTime] = timeSlot;
+
+        return obj;
+      }, {});
+
+      // Sort startTimes by ascending order
+      let sortedStartTimes = Object.keys(cuesGroupedByStartTime)
+                                   .sort((a, b) => Number(a) - Number(b));
+
+      // Map each cue group's endTime to the next group's startTime
+      sortedStartTimes.forEach((startTime, idx) => {
+        let cueGroup = cuesGroupedByStartTime[startTime];
+        let nextTime = sortedStartTimes[idx + 1] || videoDuration;
+
+        // Map each cue's endTime the next group's startTime
+        cueGroup.forEach((cue) => {
+          cue.endTime = nextTime;
+        });
+      });
     }
   }
 };

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -1130,7 +1130,7 @@ QUnit.test('translates metadata events into WebVTT cues', function() {
   QUnit.equal(cues.length, 3, 'created three cues');
   QUnit.equal(cues[0].text, 'This is a url tag', 'included the text');
   QUnit.equal(cues[0].startTime, 12, 'started at twelve');
-  QUnit.equal(cues[0].endTime, 12, 'ended at StartTime of next cue(12)');
+  QUnit.equal(cues[0].endTime, 22, 'ended at StartTime of next cue(12)');
   QUnit.equal(cues[1].text, 'This is a text tag', 'included the text');
   QUnit.equal(cues[1].startTime, 12, 'started at twelve');
   QUnit.equal(cues[1].endTime, 22, 'ended at the startTime of next cue(22)');

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -1130,7 +1130,7 @@ QUnit.test('translates metadata events into WebVTT cues', function() {
   QUnit.equal(cues.length, 3, 'created three cues');
   QUnit.equal(cues[0].text, 'This is a url tag', 'included the text');
   QUnit.equal(cues[0].startTime, 12, 'started at twelve');
-  QUnit.equal(cues[0].endTime, 22, 'ended at StartTime of next cue(12)');
+  QUnit.equal(cues[0].endTime, 22, 'ended at StartTime of next cue(22)');
   QUnit.equal(cues[1].text, 'This is a text tag', 'included the text');
   QUnit.equal(cues[1].startTime, 12, 'started at twelve');
   QUnit.equal(cues[1].endTime, 22, 'ended at the startTime of next cue(22)');


### PR DESCRIPTION
When there are ID3 tags with multiple frames, this change will create several overlapping cues that all start at the same time and all end at the same time.

This behavior is somewhat different from what Safari does but it makes more sense. I think Safari is "doing it wrong" anyway since it creates some cues that are literally 1/90000th of a second long when there are ID3 tags with multiple frames.