### PR TITLE
Flash Performance Enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prestart": "npm-run-all docs build",
     "start": "npm-run-all -p start:* watch:*",
     "start:serve": "babel-node scripts/server.js",
-    "pretest": "npm-run-all lint build",
+    "pretest": "npm-run-all build",
     "test": "karma start test/karma/detected.js",
     "test:chrome": "npm run pretest && karma start test/karma/chrome.js",
     "test:firefox": "npm run pretest && karma start test/karma/firefox.js",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prestart": "npm-run-all docs build",
     "start": "npm-run-all -p start:* watch:*",
     "start:serve": "babel-node scripts/server.js",
-    "pretest": "npm-run-all build",
+    "pretest": "npm-run-all lint build",
     "test": "karma start test/karma/detected.js",
     "test:chrome": "npm run pretest && karma start test/karma/chrome.js",
     "test:firefox": "npm run pretest && karma start test/karma/firefox.js",

--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
   ],
   "dependencies": {
     "global": "^4.3.0",
-    "mux.js": "^3.1.0",
-    "video.js": "^5.10.1",
+    "mux.js": "^4.0.1",
+    "video.js": "^5.17.0",
     "webworkify": "1.0.2"
   },
   "devDependencies": {

--- a/src/flash-constants.js
+++ b/src/flash-constants.js
@@ -13,8 +13,8 @@
  */
 const flashConstants = {
   // times in milliseconds
-  TIME_BETWEEN_CHUNKS: 4,
-  BYTES_PER_CHUNK: 4096
+  TIME_BETWEEN_CHUNKS: 0,
+  BYTES_PER_CHUNK: 1024 * 4
 };
 
 export default flashConstants;

--- a/src/flash-constants.js
+++ b/src/flash-constants.js
@@ -13,8 +13,8 @@
  */
 const flashConstants = {
   // times in milliseconds
-  TIME_BETWEEN_CHUNKS: 0,
-  BYTES_PER_CHUNK: 1024 * 4
+  TIME_BETWEEN_CHUNKS: 1,
+  BYTES_PER_CHUNK: 1024 * 32
 };
 
 export default flashConstants;

--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -25,14 +25,14 @@ const scheduleTick = function(func) {
 };
 
 /**
- * Generates a random string of length 10
+ * Generates a random string of max length 6
  *
  * @return {String} the randomly generated string
  * @function generateRandomString
  * @private
  */
 const generateRandomString = function() {
-  return (Math.random().toString(36) + '00000000000000000').slice(2, 8);
+  return (Math.random().toString(36)).slice(2, 8);
 };
 
 /**

--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -89,10 +89,11 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
     );
 
     window.encodedHeaderSuperSecret = function () {
+      delete window.encodedHeaderSuperSecret;
       throw encodedHeader;
     };
 
-    this.mediaSource_.swfObj.vjs_appendBuffer('encodedHeaderSuperSecret');
+    this.mediaSource_.swfObj.vjs_appendChunkReady('encodedHeaderSuperSecret');
 
     // TS to FLV transmuxer
     this.transmuxer_ = work(transmuxWorker);
@@ -284,6 +285,7 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
       if (this.bufferSize_ !== 0) {
         scheduleTick(this.processBuffer_.bind(this));
       } else {
+        delete window.throwDataSuperSecret;
         this.updating = false;
         this.trigger({ type: 'updateend' });
       }
@@ -293,7 +295,7 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
 
     // bypass normal ExternalInterface calls and pass xml directly
     // IE can be slow by default
-    this.mediaSource_.swfObj.vjs_appendBuffer('throwDataSuperSecret');
+    this.mediaSource_.swfObj.vjs_appendChunkReady('throwDataSuperSecret');
   }
 
   /**

--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -88,10 +88,12 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
       )
     );
 
-    window.vjs_flashEncodedHeader_ = function () {
+    /* eslint-disable camelcase */
+    window.vjs_flashEncodedHeader_ = function() {
       delete window.vjs_flashEncodedHeader_;
-      throw encodedHeader;
+      return encodedHeader;
     };
+    /* eslint-enable camelcase */
 
     this.mediaSource_.swfObj.vjs_appendChunkReady('vjs_flashEncodedHeader_');
 
@@ -280,18 +282,15 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
     }
     let b64str = window.btoa(binary.join(''));
 
-    window.vjs_flashEncodedData_ = function () {
-      // schedule another append if necessary
-      if (this.bufferSize_ !== 0) {
-        scheduleTick(this.processBuffer_.bind(this));
-      } else {
-        delete window.vjs_flashEncodedData_;
-        this.updating = false;
-        this.trigger({ type: 'updateend' });
-      }
-
-      throw b64str;
+    /* eslint-disable camelcase */
+    window.vjs_flashEncodedData_ = function() {
+      // schedule another processBuffer to process any left over data or to
+      // trigger updateend
+      scheduleTick(this.processBuffer_.bind(this));
+      delete window.vjs_flashEncodedData_;
+      return b64str;
     }.bind(this);
+    /* eslint-enable camelcase */
 
     // bypass normal ExternalInterface calls and pass xml directly
     // IE can be slow by default

--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -110,12 +110,10 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
                                    this.mediaSource_.player_.id() +
                                    generateRandomString();
 
-    /* eslint-disable camelcase */
     window[this.flashEncodedHeaderName_] = () => {
       delete window[this.flashEncodedHeaderName_];
       return encodedHeader;
     };
-    /* eslint-enable camelcase */
 
     this.mediaSource_.swfObj.vjs_appendChunkReady(this.flashEncodedHeaderName_);
 
@@ -308,7 +306,6 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
     }
     let b64str = window.btoa(binary.join(''));
 
-    /* eslint-disable camelcase */
     window[this.flashEncodedDataName_] = () => {
       // schedule another processBuffer to process any left over data or to
       // trigger updateend
@@ -316,7 +313,6 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
       delete window[this.flashEncodedDataName_];
       return b64str;
     };
-    /* eslint-enable camelcase */
 
     // Notify the swf that segment data is ready to be appended
     this.mediaSource_.swfObj.vjs_appendChunkReady(this.flashEncodedDataName_);

--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -7,6 +7,8 @@ import flv from 'mux.js/lib/flv';
 import removeCuesFromTrack from './remove-cues-from-track';
 import createTextTracksIfNecessary from './create-text-tracks-if-necessary';
 import {addTextTrackData} from './add-text-track-data';
+import transmuxWorker from './flash-transmuxer-worker';
+import work from 'webworkify';
 import FlashConstants from './flash-constants';
 
 /**
@@ -77,18 +79,24 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
     this.updating = false;
     this.timestampOffset_ = 0;
 
-    // TS to FLV transmuxer
-    this.segmentParser_ = new flv.Transmuxer();
-    this.segmentParser_.on('data', this.receiveBuffer_.bind(this));
     encodedHeader = window.btoa(
       String.fromCharCode.apply(
         null,
         Array.prototype.slice.call(
-          this.segmentParser_.getFlvHeader()
+          flv.getFlvHeader()
         )
       )
     );
     this.mediaSource_.swfObj.vjs_appendBuffer(encodedHeader);
+
+    // TS to FLV transmuxer
+    this.transmuxer_ = work(transmuxWorker);
+    this.transmuxer_.postMessage({ action: 'init', options: {} });
+    this.transmuxer_.onmessage = (event) => {
+      if (event.data.action === 'data') {
+        this.receiveBuffer_(event.data.segment);
+      }
+    };
 
     this.one('updateend', () => {
       this.mediaSource_.tech_.trigger('loadedmetadata');
@@ -101,13 +109,13 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
       set(val) {
         if (typeof val === 'number' && val >= 0) {
           this.timestampOffset_ = val;
-          this.segmentParser_ = new flv.Transmuxer();
-          this.segmentParser_.on('data', this.receiveBuffer_.bind(this));
           // We have to tell flash to expect a discontinuity
           this.mediaSource_.swfObj.vjs_discontinuity();
           // the media <-> PTS mapping must be re-established after
           // the discontinuity
           this.basePtsOffset_ = NaN;
+
+          this.transmuxer_.postMessage({ action: 'reset' });
         }
       }
     });
@@ -147,8 +155,6 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
    */
   appendBuffer(bytes) {
     let error;
-    let chunk = 512 * 1024;
-    let i = 0;
 
     if (this.updating) {
       error = new Error('SourceBuffer.append() cannot be called ' +
@@ -162,18 +168,13 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
     this.mediaSource_.readyState = 'open';
     this.trigger({ type: 'update' });
 
-    // this is here to use recursion
-    let chunkInData = () => {
-      this.segmentParser_.push(bytes.subarray(i, i + chunk));
-      i += chunk;
-      if (i < bytes.byteLength) {
-        scheduleTick(chunkInData);
-      } else {
-        scheduleTick(this.segmentParser_.flush.bind(this.segmentParser_));
-      }
-    };
-
-    chunkInData();
+    this.transmuxer_.postMessage({
+      action: 'push',
+      data: bytes.buffer,
+      byteOffset: bytes.byteOffset,
+      byteLength: bytes.byteLength
+    }, [bytes.buffer]);
+    this.transmuxer_.postMessage({action: 'flush'});
   }
 
   /**

--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -88,12 +88,12 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
       )
     );
 
-    window.encodedHeaderSuperSecret = function () {
-      delete window.encodedHeaderSuperSecret;
+    window.vjs_flashEncodedHeader_ = function () {
+      delete window.vjs_flashEncodedHeader_;
       throw encodedHeader;
     };
 
-    this.mediaSource_.swfObj.vjs_appendChunkReady('encodedHeaderSuperSecret');
+    this.mediaSource_.swfObj.vjs_appendChunkReady('vjs_flashEncodedHeader_');
 
     // TS to FLV transmuxer
     this.transmuxer_ = work(transmuxWorker);
@@ -280,12 +280,12 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
     }
     let b64str = window.btoa(binary.join(''));
 
-    window.throwDataSuperSecret = function () {
+    window.vjs_flashEncodedData_ = function () {
       // schedule another append if necessary
       if (this.bufferSize_ !== 0) {
         scheduleTick(this.processBuffer_.bind(this));
       } else {
-        delete window.throwDataSuperSecret;
+        delete window.vjs_flashEncodedData_;
         this.updating = false;
         this.trigger({ type: 'updateend' });
       }
@@ -295,7 +295,7 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
 
     // bypass normal ExternalInterface calls and pass xml directly
     // IE can be slow by default
-    this.mediaSource_.swfObj.vjs_appendChunkReady('throwDataSuperSecret');
+    this.mediaSource_.swfObj.vjs_appendChunkReady('vjs_flashEncodedData_');
   }
 
   /**
@@ -437,7 +437,7 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
         tag = videoTags.shift();
       }
 
-      tags.push(tag.finalize());
+      tags.push(tag);
     }
 
     return tags;

--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -102,12 +102,17 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
     // create function names with added randomness for the global callbacks flash will use
     // to get data from javascript into the swf. Random strings are added as a safety
     // measure for pages with multiple players since these functions will be global
-    // instead of per instance.
+    // instead of per instance. When making a call to the swf, the browser generates a
+    // try catch code snippet, but just takes the function name and writes out an unquoted
+    // call to that function. If the player id has any special characters, this will result
+    // in an error, so safePlayerId replaces all special characters to '_'
+    const safePlayerId = this.mediaSource_.player_.id().replace(/[^a-zA-Z0-9]/g, '_');
+
     this.flashEncodedHeaderName_ = 'vjs_flashEncodedHeader_' +
-                                   this.mediaSource_.player_.id() +
+                                   safePlayerId +
                                    generateRandomString();
     this.flashEncodedDataName_ = 'vjs_flashEncodedData_' +
-                                   this.mediaSource_.player_.id() +
+                                   safePlayerId +
                                    generateRandomString();
 
     window[this.flashEncodedHeaderName_] = () => {

--- a/src/flash-transmuxer-worker.js
+++ b/src/flash-transmuxer-worker.js
@@ -15,33 +15,6 @@
 import window from 'global/window';
 import flv from 'mux.js/lib/flv';
 
-const orderTags = function(tags) {
-  let videoTags = tags.videoTags;
-  let audioTags = tags.audioTags;
-  let ordered = [];
-  let tag;
-
-  while (videoTags.length || audioTags.length) {
-    if (!videoTags.length) {
-      // only audio tags remain
-      tag = audioTags.shift();
-    } else if (!audioTags.length) {
-      // only video tags remain
-      tag = videoTags.shift();
-    } else if (audioTags[0].dts < videoTags[0].dts) {
-      // audio should be decoded next
-      tag = audioTags.shift();
-    } else {
-      // video should be decoded next
-      tag = videoTags.shift();
-    }
-
-    ordered.push(tag);
-  }
-
-  return ordered;
-}
-
 /**
  * Re-emits tranmsuxer events by converting them into messages to the
  * world outside the worker.
@@ -51,9 +24,6 @@ const orderTags = function(tags) {
  */
 const wireTransmuxerEvents = function(transmuxer) {
   transmuxer.on('data', function(segment) {
-
-    // segment.tags = orderTags(segment.tags);
-
     window.postMessage({
       action: 'data',
       segment

--- a/src/flash-transmuxer-worker.js
+++ b/src/flash-transmuxer-worker.js
@@ -1,0 +1,152 @@
+/**
+ * @file flash-worker.js
+ */
+
+/**
+ * videojs-contrib-media-sources
+ *
+ * Copyright (c) 2015 Brightcove
+ * All rights reserved.
+ *
+ * Handles communication between the browser-world and the mux.js
+ * transmuxer running inside of a WebWorker by exposing a simple
+ * message-based interface to a Transmuxer object.
+ */
+import window from 'global/window';
+import flv from 'mux.js/lib/flv';
+
+const orderTags = function(tags) {
+  let videoTags = tags.videoTags;
+  let audioTags = tags.audioTags;
+  let ordered = [];
+  let tag;
+
+  while (videoTags.length || audioTags.length) {
+    if (!videoTags.length) {
+      // only audio tags remain
+      tag = audioTags.shift();
+    } else if (!audioTags.length) {
+      // only video tags remain
+      tag = videoTags.shift();
+    } else if (audioTags[0].dts < videoTags[0].dts) {
+      // audio should be decoded next
+      tag = audioTags.shift();
+    } else {
+      // video should be decoded next
+      tag = videoTags.shift();
+    }
+
+    ordered.push(tag);
+  }
+
+  return ordered;
+}
+
+/**
+ * Re-emits tranmsuxer events by converting them into messages to the
+ * world outside the worker.
+ *
+ * @param {Object} transmuxer the transmuxer to wire events on
+ * @private
+ */
+const wireTransmuxerEvents = function(transmuxer) {
+  transmuxer.on('data', function(segment) {
+
+    segment.tags = orderTags(segment.tags);
+
+    window.postMessage({
+      action: 'data',
+      segment
+    });
+  });
+
+  transmuxer.on('done', function(data) {
+    window.postMessage({ action: 'done' });
+  });
+};
+
+/**
+ * All incoming messages route through this hash. If no function exists
+ * to handle an incoming message, then we ignore the message.
+ *
+ * @class MessageHandlers
+ * @param {Object} options the options to initialize with
+ */
+class MessageHandlers {
+  constructor(options) {
+    this.options = options || {};
+    this.init();
+  }
+
+  /**
+   * initialize our web worker and wire all the events.
+   */
+  init() {
+    if (this.transmuxer) {
+      this.transmuxer.dispose();
+    }
+    this.transmuxer = new flv.Transmuxer(this.options);
+    wireTransmuxerEvents(this.transmuxer);
+  }
+
+  /**
+   * Adds data (a ts segment) to the start of the transmuxer pipeline for
+   * processing.
+   *
+   * @param {ArrayBuffer} data data to push into the muxer
+   */
+  push(data) {
+    // Cast array buffer to correct type for transmuxer
+    let segment = new Uint8Array(data.data, data.byteOffset, data.byteLength);
+
+    this.transmuxer.push(segment);
+  }
+
+  /**
+   * Recreate the transmuxer so that the next segment added via `push`
+   * start with a fresh transmuxer.
+   */
+  reset() {
+    this.init();
+  }
+
+  /**
+   * Forces the pipeline to finish processing the last segment and emit it's
+   * results.
+   *
+   * @param {Object} data event data, not really used
+   */
+  flush(data) {
+    this.transmuxer.flush();
+  }
+}
+
+/**
+ * Our web wroker interface so that things can talk to mux.js
+ * that will be running in a web worker. the scope is passed to this by
+ * webworkify.
+ *
+ * @param {Object} self the scope for the web worker
+ */
+const Worker = function(self) {
+  self.onmessage = function(event) {
+    if (event.data.action === 'init' && event.data.options) {
+      this.messageHandlers = new MessageHandlers(event.data.options);
+      return;
+    }
+
+    if (!this.messageHandlers) {
+      this.messageHandlers = new MessageHandlers();
+    }
+
+    if (event.data && event.data.action && event.data.action !== 'init') {
+      if (this.messageHandlers[event.data.action]) {
+        this.messageHandlers[event.data.action](event.data);
+      }
+    }
+  };
+};
+
+export default (self) => {
+  return new Worker(self);
+};

--- a/src/flash-transmuxer-worker.js
+++ b/src/flash-transmuxer-worker.js
@@ -1,22 +1,11 @@
 /**
- * @file flash-worker.js
- */
-
-/**
- * videojs-contrib-media-sources
- *
- * Copyright (c) 2015 Brightcove
- * All rights reserved.
- *
- * Handles communication between the browser-world and the mux.js
- * transmuxer running inside of a WebWorker by exposing a simple
- * message-based interface to a Transmuxer object.
+ * @file flash-transmuxer-worker.js
  */
 import window from 'global/window';
 import flv from 'mux.js/lib/flv';
 
 /**
- * Re-emits tranmsuxer events by converting them into messages to the
+ * Re-emits transmuxer events by converting them into messages to the
  * world outside the worker.
  *
  * @param {Object} transmuxer the transmuxer to wire events on
@@ -81,19 +70,17 @@ class MessageHandlers {
   }
 
   /**
-   * Forces the pipeline to finish processing the last segment and emit it's
+   * Forces the pipeline to finish processing the last segment and emit its
    * results.
-   *
-   * @param {Object} data event data, not really used
    */
-  flush(data) {
+  flush() {
     this.transmuxer.flush();
   }
 }
 
 /**
  * Our web wroker interface so that things can talk to mux.js
- * that will be running in a web worker. the scope is passed to this by
+ * that will be running in a web worker. The scope is passed to this by
  * webworkify.
  *
  * @param {Object} self the scope for the web worker

--- a/src/flash-transmuxer-worker.js
+++ b/src/flash-transmuxer-worker.js
@@ -52,7 +52,7 @@ const orderTags = function(tags) {
 const wireTransmuxerEvents = function(transmuxer) {
   transmuxer.on('data', function(segment) {
 
-    segment.tags = orderTags(segment.tags);
+    // segment.tags = orderTags(segment.tags);
 
     window.postMessage({
       action: 'data',

--- a/src/transmuxer-worker.js
+++ b/src/transmuxer-worker.js
@@ -16,7 +16,7 @@ import window from 'global/window';
 import mp4 from 'mux.js/lib/mp4';
 
 /**
- * Re-emits tranmsuxer events by converting them into messages to the
+ * Re-emits transmuxer events by converting them into messages to the
  * world outside the worker.
  *
  * @param {Object} transmuxer the transmuxer to wire events on

--- a/test/flash.test.js
+++ b/test/flash.test.js
@@ -175,7 +175,7 @@ QUnit.module('Flash MediaSource', {
         let chunk = window[method]();
 
         // only care about the segment data, not the flv header
-        if (method === 'vjs_flashEncodedData_') {
+        if (method.substr(0, 21) === 'vjs_flashEncodedData_') {
           let call = {
             callee: 'vjs_appendChunkReady',
             arguments: [window.atob(chunk).split('').map((c) => c.charCodeAt(0))]

--- a/test/flash.test.js
+++ b/test/flash.test.js
@@ -68,17 +68,17 @@ const unfakeSTO = function() {
 };
 
 // Create a WebWorker-style message that signals the transmuxer is done
-const createDataMessage = function(datas, audioDatas, metadata, captions) {
+const createDataMessage = function(data, audioData, metadata, captions) {
   return {
     data: {
       action: 'data',
       segment: {
         tags: {
-          videoTags: datas.map((data) => {
-            return makeFlvTag(data.pts, data.bytes);
+          videoTags: data.map((tag) => {
+            return makeFlvTag(tag.pts, tag.bytes);
           }),
-          audioTags: audioDatas ? audioDatas.map((data) => {
-            return makeFlvTag(data.pts, data.bytes);
+          audioTags: audioData ? audioData.map((tag) => {
+            return makeFlvTag(tag.pts, tag.bytes);
           }) : []
         },
         metadata,

--- a/test/flash.test.js
+++ b/test/flash.test.js
@@ -173,6 +173,7 @@ QUnit.module('Flash MediaSource', {
     swfObj.vjs_appendChunkReady = (method) => {
       window.setTimeout(() => {
         let chunk = window[method]();
+
         // only care about the segment data, not the flv header
         if (method === 'vjs_flashEncodedData_') {
           let call = {


### PR DESCRIPTION
Currently, the flash fallback is not so great. In situations where a user has low bandwidth or a not so powerful cpu, they may experience frequent and long buffering through playback.  This is primarily due to the way segments are transferred to the swf.  In order to not freeze up the main thread, we have to chunk up the segment data into very small 4k chunks to transmux and append each one asynchronously. 

**This PR requires [video-js-swf #218](https://github.com/videojs/video-js-swf/pull/218) and [mux.js #139](https://github.com/videojs/mux.js/pull/139)**

This PR brings two main enhancements.
* Transmuxing in a web worker
  * By moving the transmuxer to the webworker, we can transmux the entire segment at once without taking up the main thread. This gives us more "time" to process things in the main thread.
* Pull from flash instead of Push to flash
  * Instead of pushing data to flash like we do now with the ExternalInterface CallFunction, this adds an intermediate call to the swf that tells flash we have data ready for it. Flash then uses ExternalInterface to call a global function in javascript, which returns the segment bytes. Allowing the swf to initiate and handle the transfer seems to allow larger chunks of transfer without slowing the javascript thread. This change allows us to increase the chunksize 8-fold to 32kb.