### PR TITLE
Don't swallow append exceptions

### DIFF
--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -498,7 +498,9 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
         if (this.mediaSource_.player_) {
           this.mediaSource_.player_.error({
             code: -3,
-            type: 'APPEND_BUFFER_ERR'
+            type: 'APPEND_BUFFER_ERR',
+            message: error.message,
+            originalError: error
           });
         }
       }


### PR DESCRIPTION
Pass along exceptions that are triggered when appending data as a property on the synthetic player error.