### PR TITLE
Revert worker for flash transmuxing

### DIFF
--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -172,10 +172,6 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
       removeCuesFromTrack(0, Infinity, this.metadataTrack_);
       removeCuesFromTrack(0, Infinity, this.inbandTextTrack_);
     });
-
-    this.mediaSource_.player_.tech_.hls.on('dispose', () => {
-      this.transmuxer_.terminate();
-    });
   }
 
   /**
@@ -379,15 +375,14 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
     const getKeyFrameIndex = (tag, index) => {
       if (tag.metaDataTag) {
         return index + 2;
-      } else {
-        return index;
       }
+      return index;
     };
 
     // verifies the given index is valid index and points to a key frame
     const verifyKeyFrameIndex = (tags, index) => {
       return (tags[index] && tags[index].keyFrame);
-    }
+    };
 
     // filter complete GOPs with a presentation time less than the seek target/end of buffer
     let startIndex = 0;

--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -343,8 +343,6 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
     let videoTags = segmentData.tags.videoTags;
     let audioTags = segmentData.tags.audioTags;
 
-    console.log('*** CONVERT TAGS TO DATA ***');
-
     // Establish the media timeline to PTS translation if we don't
     // have one already
     if (isNaN(this.basePtsOffset_) && (videoTags.length || audioTags.length)) {
@@ -357,14 +355,8 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
       this.basePtsOffset_ = Math.min(firstAudioTag.pts, firstVideoTag.pts);
     }
 
-    console.log('>> BASEPTS OFFSET', this.basePtsOffset_);
-    console.log('>> TIMESTAMP OFFSET', this.timestampOffset);
-    console.log('>> CURRENT TIME', tech.currentTime());
-    console.log('>> SEEKING', tech.seeking());
-
     if (tech.buffered().length) {
       targetPts = tech.buffered().end(0) - this.timestampOffset;
-      console.log('>> BUFFERED END', tech.buffered().end(0));
     }
 
     // Trim to currentTime if it's ahead of buffered or buffered doesn't exist
@@ -376,19 +368,12 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
     targetPts *= 1e3;
     targetPts += this.basePtsOffset_;
 
-    console.log('>> TARGET PTS', targetPts);
-
     // skip tags with a presentation time less than the seek target/end of buffer
     for (let i = 0; i < audioTags.length; i++) {
       if (audioTags[i].pts >= targetPts) {
         filteredAudioTags.push(audioTags[i]);
       }
     }
-
-    if (audioTags.length) {
-      console.log('>> Audio PTS', audioTags[0].pts, '-->', audioTags[audioTags.length - 1].pts);
-    }
-    console.log('>> FILTERED', audioTags.length - filteredAudioTags.length, 'AUDIO TAGS OF', audioTags.length);
 
     // gets the index of the key frame based on whether the tag is a metadata tag or not
     const getKeyFrameIndex = (tag, index) => {
@@ -459,12 +444,6 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
       }
       startIndex++;
     }
-
-    if (videoTags.length) {
-      console.log('>> VIDEO PTS', videoTags[0].pts, '-->', videoTags[videoTags.length - 1].pts);
-    }
-    console.log('>> FILTERED', videoTags.length - filteredVideoTags.length, 'VIDEO TAGS OF', videoTags.length);
-
 
     let tags = this.getOrderedTags_(filteredVideoTags, filteredAudioTags);
 

--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -379,7 +379,7 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
       return index;
     };
 
-    // verifies the given index is valid index and points to a key frame
+    // verifies the given index is valid and points to a key frame
     const verifyKeyFrameIndex = (tags, index) => {
       return (tags[index] && tags[index].keyFrame);
     };
@@ -411,11 +411,7 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
           } else if (nextTag.metaDataTag || nextTag.keyFrame) {
             let nextKeyFrameIndex = getKeyFrameIndex(nextTag, nextIndex);
 
-            if (!verifyKeyFrameIndex(videoTags, nextKeyFrameIndex)) {
-              break;
-            }
-
-            foundNextKeyFrame = true;
+            foundNextKeyFrame = verifyKeyFrameIndex(videoTags, nextKeyFrameIndex);
             break;
           } else {
             nextIndex++;

--- a/src/flash-transmuxer-worker.js
+++ b/src/flash-transmuxer-worker.js
@@ -85,7 +85,7 @@ class MessageHandlers {
  *
  * @param {Object} self the scope for the web worker
  */
-const Worker = function(self) {
+const FlashTransmuxerWorker = function(self) {
   self.onmessage = function(event) {
     if (event.data.action === 'init' && event.data.options) {
       this.messageHandlers = new MessageHandlers(event.data.options);
@@ -105,5 +105,5 @@ const Worker = function(self) {
 };
 
 export default (self) => {
-  return new Worker(self);
+  return new FlashTransmuxerWorker(self);
 };

--- a/src/transmuxer-worker.js
+++ b/src/transmuxer-worker.js
@@ -141,7 +141,7 @@ class MessageHandlers {
  *
  * @param {Object} self the scope for the web worker
  */
-const Worker = function(self) {
+const TransmuxerWorker = function(self) {
   self.onmessage = function(event) {
     if (event.data.action === 'init' && event.data.options) {
       this.messageHandlers = new MessageHandlers(event.data.options);
@@ -161,5 +161,5 @@ const Worker = function(self) {
 };
 
 export default (self) => {
-  return new Worker(self);
+  return new TransmuxerWorker(self);
 };

--- a/test/flash.test.js
+++ b/test/flash.test.js
@@ -87,24 +87,43 @@ const createDataMessage = function(data, audioData, metadata, captions) {
     }
   };
 };
-const doneMessage = {
-  data: {
-    action: 'done'
-  }
-};
-const postMessage_ = function(msg) {
-  if (msg.action === 'push') {
-    window.setTimeout(()=> {
-      this.onmessage(createDataMessage([{
-        bytes: new Uint8Array(msg.data, msg.byteOffset, msg.byteLength),
-        pts: 0
-      }]));
-    }, 1);
-  } else if (msg.action === 'flush') {
-    window.setTimeout(() => {
-      this.onmessage(doneMessage);
-    }, 1);
-  }
+
+const MockSegmentParser = function() {
+  let ons = {};
+  let datas = [];
+
+  this.on = function(type, fn) {
+    if (!ons[type]) {
+      ons[type] = [fn];
+    } else {
+      ons[type].push(fn);
+    }
+  };
+  this.trigger = function(type, data) {
+    if (ons[type]) {
+      ons[type].forEach(function(fn) {
+        fn(data);
+      });
+    }
+  };
+
+  this.push = function(data) {
+    datas.push(data);
+  };
+  this.flush = function() {
+    let tags = datas.reduce(function(output, data, i) {
+      output.push(makeFlvTag(i, data));
+      return output;
+    }, []);
+
+    datas.length = 0;
+    this.trigger('data', {
+      tags: {
+        videoTags: tags,
+        audioTags: []
+      }
+    });
+  };
 };
 
 QUnit.module('Flash MediaSource', {
@@ -132,7 +151,8 @@ QUnit.module('Flash MediaSource', {
       return true;
     };
 
-    this.oldFlashTransmuxerPostMessage = muxjs.flv.Transmuxer.postMessage;
+    this.oldFlashTransmuxer = muxjs.flv.Transmuxer;
+    muxjs.flv.Transmuxer = MockSegmentParser;
     this.oldGetFlvHeader = muxjs.flv.getFlvHeader;
     muxjs.flv.getFlvHeader = getFlvHeader;
 
@@ -198,7 +218,7 @@ QUnit.module('Flash MediaSource', {
     window.WebKitMediaSource = window.MediaSource;
     this.Flash.isSupported = this.oldFlashSupport;
     this.Flash.canPlaySource = this.oldCanPlay;
-    muxjs.flv.Transmuxer.postMessage = this.oldFlashTransmuxerPostMessage;
+    muxjs.flv.Transmuxer = this.oldFlashTransmuxer;
     muxjs.flv.getFlvHeader = this.oldGetFlvHeader;
     this.player.dispose();
     this.clock.restore();
@@ -225,8 +245,6 @@ QUnit.test('creates FlashSourceBuffers for video/mp2t', function() {
 QUnit.test('waits for the next tick to append', function() {
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
 
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
-
   QUnit.equal(this.swfCalls.length, 1, 'made one call on init');
   QUnit.equal(this.swfCalls[0], 'load', 'called load');
   sourceBuffer.appendBuffer(new Uint8Array([0, 1]));
@@ -236,8 +254,6 @@ QUnit.test('waits for the next tick to append', function() {
 
 QUnit.test('passes bytes to Flash', function() {
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
-
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
 
   this.swfCalls.length = 0;
   sourceBuffer.appendBuffer(new Uint8Array([0, 1]));
@@ -255,8 +271,6 @@ QUnit.test('passes bytes to Flash', function() {
 QUnit.test('passes chunked bytes to Flash', function() {
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
   let oldChunkSize = FlashConstants.BYTES_PER_CHUNK;
-
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
 
   FlashConstants.BYTES_PER_CHUNK = 2;
 
@@ -303,8 +317,6 @@ QUnit.test('drops tags before currentTime when seeking', function() {
   let currentTime;
   let tags_ = [];
 
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
-
   this.mediaSource.tech_.currentTime = function() {
     return currentTime;
   };
@@ -312,10 +324,12 @@ QUnit.test('drops tags before currentTime when seeking', function() {
   // push a tag into the buffer to establish the starting PTS value
   currentTime = 0;
 
-  sourceBuffer.transmuxer_.onmessage(createDataMessage([{
+  let dataMessage = createDataMessage([{
     pts: 19 * 1000,
     bytes: new Uint8Array(1)
-  }]));
+  }]);
+
+  sourceBuffer.transmuxer_.trigger('data', dataMessage.data.segment);
 
   timers.runAll();
 
@@ -332,7 +346,10 @@ QUnit.test('drops tags before currentTime when seeking', function() {
       }
     );
   }
-  sourceBuffer.transmuxer_.onmessage(createDataMessage(tags_));
+
+  dataMessage = createDataMessage(tags_);
+
+  sourceBuffer.transmuxer_.trigger('data', dataMessage.data.segment);
 
   // seek to 7 seconds into the new swegment
   this.mediaSource.tech_.seeking = function() {
@@ -355,8 +372,6 @@ QUnit.test('drops audio and video (complete gops) tags before the buffered end a
   let videoTags_ = [];
   let audioTags_ = [];
 
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
-
   this.mediaSource.tech_.buffered = function() {
     return videojs.createTimeRange([[0, endTime]]);
   };
@@ -364,13 +379,15 @@ QUnit.test('drops audio and video (complete gops) tags before the buffered end a
   // push a tag into the buffer to establish the starting PTS value
   endTime = 0;
 
-  sourceBuffer.transmuxer_.onmessage(createDataMessage([{
+  let dataMessage = createDataMessage([{
     pts: 19 * 1000,
     bytes: new Uint8Array(1)
   }], [{
     pts: 19 * 1000,
     bytes: new Uint8Array(1)
-  }]));
+  }]);
+
+  sourceBuffer.transmuxer_.trigger('data', dataMessage.data.segment);
 
   timers.runAll();
 
@@ -394,14 +411,14 @@ QUnit.test('drops audio and video (complete gops) tags before the buffered end a
     });
   }
 
-  let dataMessage = createDataMessage(videoTags_, audioTags_);
+  dataMessage = createDataMessage(videoTags_, audioTags_);
 
   dataMessage.data.segment.tags.videoTags[0].keyFrame = true;
   dataMessage.data.segment.tags.videoTags[3].keyFrame = true;
   dataMessage.data.segment.tags.videoTags[6].keyFrame = true;
   dataMessage.data.segment.tags.videoTags[8].keyFrame = true;
 
-  sourceBuffer.transmuxer_.onmessage(dataMessage);
+  sourceBuffer.transmuxer_.trigger('data', dataMessage.data.segment);
 
   endTime = 10 + 7;
   this.mediaSource.tech_.trigger('seeking');
@@ -426,18 +443,18 @@ QUnit.test('seek targeting accounts for changing timestampOffsets', function() {
   let tags_ = [];
   let currentTime;
 
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
-
   this.mediaSource.tech_.currentTime = function() {
     return currentTime;
   };
 
-  // push a tag into the buffer to establish the starting PTS value
-  currentTime = 0;
-  sourceBuffer.transmuxer_.onmessage(createDataMessage([{
+  let dataMessage = createDataMessage([{
     pts: 19 * 1000,
     bytes: new Uint8Array(1)
-  }]));
+  }]);
+
+  // push a tag into the buffer to establish the starting PTS value
+  currentTime = 0;
+  sourceBuffer.transmuxer_.trigger('data', dataMessage.data.segment);
   timers.runAll();
 
   // to seek across a discontinuity:
@@ -458,7 +475,10 @@ QUnit.test('seek targeting accounts for changing timestampOffsets', function() {
       bytes: new Uint8Array([i + sourceBuffer.timestampOffset])
     });
   }
-  sourceBuffer.transmuxer_.onmessage(createDataMessage(tags_));
+
+  dataMessage = createDataMessage(tags_);
+
+  sourceBuffer.transmuxer_.trigger('data', dataMessage.data.segment);
 
   this.mediaSource.tech_.trigger('seeking');
   this.swfCalls.length = 0;
@@ -471,8 +491,6 @@ QUnit.test('seek targeting accounts for changing timestampOffsets', function() {
 
 QUnit.test('calling endOfStream sets mediaSource readyState to ended', function() {
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
-
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
 
   /* eslint-disable camelcase */
   this.mediaSource.swfObj.vjs_endOfStream = () => {
@@ -508,8 +526,6 @@ QUnit.test('opens the stream on sourceBuffer.appendBuffer after endOfStream', fu
     this.mediaSource.endOfStream();
     sourceBuffer.removeEventListener('updateend', foo);
   };
-
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
 
   /* eslint-disable camelcase */
   this.mediaSource.swfObj.vjs_endOfStream = () => {
@@ -550,8 +566,6 @@ QUnit.test('opens the stream on sourceBuffer.appendBuffer after endOfStream', fu
 QUnit.test('abort() clears any buffered input', function() {
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
 
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
-
   this.swfCalls.length = 0;
   sourceBuffer.appendBuffer(new Uint8Array([0]));
   sourceBuffer.abort();
@@ -574,7 +588,7 @@ QUnit.test('does not use requestAnimationFrame', function() {
   };
 
   sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
+
   sourceBuffer.appendBuffer(new Uint8Array([0, 1, 2, 3]));
   while (timers.length) {
     timers.pop()();
@@ -585,8 +599,6 @@ QUnit.test('does not use requestAnimationFrame', function() {
 QUnit.test('updating is true while an append is in progress', function() {
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
   let ended = false;
-
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
 
   sourceBuffer.addEventListener('updateend', function() {
     ended = true;
@@ -606,7 +618,6 @@ QUnit.test('throws an error if append is called while updating', function() {
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
 
   sourceBuffer.appendBuffer(new Uint8Array([0, 1]));
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
 
   QUnit.throws(function() {
     sourceBuffer.appendBuffer(new Uint8Array([0, 1]));
@@ -619,8 +630,6 @@ QUnit.test('throws an error if append is called while updating', function() {
 QUnit.test('stops updating if abort is called', function() {
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
   let updateEnds = 0;
-
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
 
   sourceBuffer.addEventListener('updateend', function() {
     updateEnds++;
@@ -661,8 +670,6 @@ QUnit.test('calculates the base PTS for the media', function() {
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
   let tags_ = [];
 
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
-
   // seek to 15 seconds
   this.player.tech_.seeking = function() {
     return true;
@@ -678,7 +685,9 @@ QUnit.test('calculates the base PTS for the media', function() {
     { pts: (15 + 3) * 90000, bytes: new Uint8Array([15]) }
   );
 
-  sourceBuffer.transmuxer_.onmessage(createDataMessage(tags_));
+  let dataMessage = createDataMessage(tags_);
+
+  sourceBuffer.transmuxer_.trigger('data', dataMessage.data.segment);
 
   // let the source buffer know the segment start time
   sourceBuffer.timestampOffset = 10;
@@ -694,7 +703,6 @@ QUnit.test('remove fires update events', function() {
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
   let events = [];
 
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
   sourceBuffer.on(['update', 'updateend'], function(event) {
     events.push(event.type);
   });
@@ -728,8 +736,6 @@ QUnit.test('fires loadedmetadata after first segment append', function() {
 
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
 
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
-
   QUnit.equal(loadedmetadataCount, 0, 'loadedmetadata not called on buffer creation');
   sourceBuffer.appendBuffer(new Uint8Array([0, 1]));
   QUnit.equal(loadedmetadataCount, 0, 'loadedmetadata not called on segment append');
@@ -742,8 +748,6 @@ QUnit.test('fires loadedmetadata after first segment append', function() {
 
 QUnit.test('cleans up WebVTT cues on hls dispose', function() {
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
-
-  sourceBuffer.transmuxer_.postMessage = postMessage_;
 
   let addedTracks = [];
   let removedTracks = [];
@@ -788,7 +792,9 @@ QUnit.test('cleans up WebVTT cues on hls dispose', function() {
     }
   };
 
-  sourceBuffer.transmuxer_.onmessage(createDataMessage([], [], metadata, captions));
+  let dataMessage = createDataMessage([], [], metadata, captions);
+
+  sourceBuffer.transmuxer_.trigger('data', dataMessage.data.segment);
 
   QUnit.equal(addedTracks.length, 2, 'created two text tracks');
   QUnit.equal(addedTracks.filter(t => ['captions', 'metadata'].indexOf(t.kind) === -1).length,

--- a/test/flash.test.js
+++ b/test/flash.test.js
@@ -699,6 +699,18 @@ QUnit.test('calculates the base PTS for the media', function() {
   QUnit.deepEqual(this.swfCalls[0].arguments[0], [15], 'dropped the early tag');
 });
 
+QUnit.test('flushes the transmuxer after each append', function() {
+  let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
+  let flushes = 0;
+
+  sourceBuffer.transmuxer_.flush = function() {
+    flushes++;
+  };
+  sourceBuffer.appendBuffer(new Uint8Array([0, 1]));
+  timers.pop()();
+  QUnit.equal(flushes, 1, 'flushed the transmuxer');
+});
+
 QUnit.test('remove fires update events', function() {
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
   let events = [];

--- a/test/flash.test.js
+++ b/test/flash.test.js
@@ -351,6 +351,8 @@ QUnit.test('drops tags before currentTime when seeking', function() {
   }
 
   dataMessage = createDataMessage(tags_);
+  // mock gop start at seek point
+  dataMessage.data.segment.tags.videoTags[7].keyFrame = true;
 
   sourceBuffer.transmuxer_.trigger('data', dataMessage.data.segment);
 
@@ -564,7 +566,6 @@ QUnit.test('GOP trimming accounts for metadata tags prepended to key frames by m
     bytes: new Uint8Array([0])
   });
 
-
   dataMessage = createDataMessage(tags_);
 
   // mock the GOP structure + metadata tags
@@ -610,6 +611,65 @@ QUnit.test('GOP trimming accounts for metadata tags prepended to key frames by m
             '10 tags are appended, 4 of which are metadata tags');
 });
 
+QUnit.test('drops all tags if target pts append time does not fall within segment', function() {
+  let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
+  let i = 10;
+  let currentTime;
+  let tags_ = [];
+
+  this.mediaSource.tech_.currentTime = function() {
+    return currentTime;
+  };
+
+  // push a tag into the buffer to establish the starting PTS value
+  currentTime = 0;
+
+  let dataMessage = createDataMessage([{
+    pts: 19 * 1000,
+    bytes: new Uint8Array(1)
+  }]);
+
+  sourceBuffer.transmuxer_.trigger('data', dataMessage.data.segment);
+
+  timers.runAll();
+
+  sourceBuffer.appendBuffer(new Uint8Array(10));
+  timers.runAll();
+
+  // mock out a new segment of FLV tags, starting 10s after the
+  // starting PTS value
+  while (i--) {
+    tags_.unshift(
+      {
+        pts: (i * 1000) + (19 * 1000),
+        bytes: new Uint8Array([i])
+      }
+    );
+  }
+
+  dataMessage = createDataMessage(tags_);
+
+  // mock the GOP structure
+  dataMessage.data.segment.tags.videoTags[0].keyFrame = true;
+  dataMessage.data.segment.tags.videoTags[3].keyFrame = true;
+  dataMessage.data.segment.tags.videoTags[5].keyFrame = true;
+  dataMessage.data.segment.tags.videoTags[8].keyFrame = true;
+
+  sourceBuffer.transmuxer_.trigger('data', dataMessage.data.segment);
+
+  // seek to 7 seconds into the new swegment
+  this.mediaSource.tech_.seeking = function() {
+    return true;
+  };
+  currentTime = 10 + 7;
+  this.mediaSource.tech_.trigger('seeking');
+  sourceBuffer.appendBuffer(new Uint8Array(10));
+  this.swfCalls.length = 0;
+  timers.runAll();
+
+  QUnit.equal(this.swfCalls.length, 0, 'dropped all tags and made no swf calls');
+});
+
 QUnit.test('seek targeting accounts for changing timestampOffsets', function() {
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
   let i = 10;
@@ -650,6 +710,8 @@ QUnit.test('seek targeting accounts for changing timestampOffsets', function() {
   }
 
   dataMessage = createDataMessage(tags_);
+  // mock gop start at seek point
+  dataMessage.data.segment.tags.videoTags[3].keyFrame = true;
 
   sourceBuffer.transmuxer_.trigger('data', dataMessage.data.segment);
 
@@ -657,8 +719,9 @@ QUnit.test('seek targeting accounts for changing timestampOffsets', function() {
   this.swfCalls.length = 0;
   timers.runAll();
 
-  QUnit.deepEqual(this.swfCalls[0].arguments[0],
-            [26, 27, 28, 29, 30, 31],
+  QUnit.equal(this.swfCalls[0].value, 25, 'adjusted current time');
+  QUnit.deepEqual(this.swfCalls[1].arguments[0],
+            [25, 26, 27, 28, 29, 30, 31],
             'filtered the appended tags');
 });
 
@@ -854,11 +917,14 @@ QUnit.test('calculates the base PTS for the media', function() {
   // timeline
   tags_.push(
     // zero in the media timeline is PTS 3
-    { pts: (10 + 3) * 90000, bytes: new Uint8Array([10]) },
-    { pts: (15 + 3) * 90000, bytes: new Uint8Array([15]) }
+    { pts: (10 + 3) * 1000, bytes: new Uint8Array([10]) },
+    { pts: (15 + 3) * 1000, bytes: new Uint8Array([15]) }
   );
 
   let dataMessage = createDataMessage(tags_);
+
+  // mock gop start at seek point
+  dataMessage.data.segment.tags.videoTags[1].keyFrame = true;
 
   sourceBuffer.transmuxer_.trigger('data', dataMessage.data.segment);
 


### PR DESCRIPTION
There were some issues with flash playback after #126 so this PR takes out the transmuxing in a web worker to be reviewed later and corrects the logic for trimming video tags to account for metadata tags added before key frames by the muxer

requires https://github.com/videojs/mux.js/pull/141

## Note
This should not be merged in until https://github.com/videojs/video-js-swf/pull/219 has been merged, released, and the swf url is updated in video.js