### PR TITLE
Fix flash tag trimming to not append duplicate tags

### DIFF
--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -377,7 +377,12 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
       videoTargetPts *= 1e3;
       videoTargetPts += this.basePtsOffset_;
     } else {
-      videoTargetPts = this.videoBufferEnd_;
+      // Add a fudge factor of 0.1 to the last video pts appended since a rendition change
+      // could append an overlapping segment, in which case there is a high likelyhood
+      // a tag could have a matching pts to videoBufferEnd_, which would cause
+      // that tag to get appended by the tag.pts >= targetPts check below even though it
+      // is a duplicate of what was previously appended
+      videoTargetPts = this.videoBufferEnd_ + 0.1;
     }
 
     // filter complete GOPs with a presentation time less than the seek target/end of buffer
@@ -425,7 +430,12 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
     if (isNaN(this.audioBufferEnd_)) {
       audioTargetPts = videoTargetPts;
     } else {
-      audioTargetPts = this.audioBufferEnd_;
+      // Add a fudge factor of 0.1 to the last video pts appended since a rendition change
+      // could append an overlapping segment, in which case there is a high likelyhood
+      // a tag could have a matching pts to videoBufferEnd_, which would cause
+      // that tag to get appended by the tag.pts >= targetPts check below even though it
+      // is a duplicate of what was previously appended
+      audioTargetPts = this.audioBufferEnd_ + 0.1;
     }
 
     if (filteredVideoTags.length) {

--- a/test/flash.test.js
+++ b/test/flash.test.js
@@ -809,6 +809,8 @@ QUnit.test('opens the stream on sourceBuffer.appendBuffer after endOfStream', fu
         'the second call should be for the updateend');
 
   sourceBuffer.appendBuffer(new Uint8Array([2, 3]));
+  // remove previous video pts save because mock appends don't have actual timing data
+  sourceBuffer.videoBufferEnd_ = NaN;
   timers.runAll();
 
   QUnit.strictEqual(this.swfCalls.length, 1, 'made one more append');


### PR DESCRIPTION
#136 introduced a change to track the last pts values of audio and video tags appended to the buffer to use as the target trim point for the next segment. This caused duplicate tags (usually the final GOP of the last segment appended) to be appended due to a `>=`. This change adds a fudge factor of `0.1` to the target pts when using the last stored pts value to avoid mistakenly appending a duplicate GOP