### PR TITLE
Support for multiple CEA608 tracks

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   ],
   "dependencies": {
     "global": "^4.3.0",
-    "mux.js": "4.1.5",
+    "mux.js": "4.2.0",
     "video.js": "^5.17.0",
     "webworkify": "1.0.2"
   },

--- a/src/add-text-track-data.js
+++ b/src/add-text-track-data.js
@@ -64,7 +64,9 @@ const addTextTrackData = function(sourceHandler, captionArray, metadataArray) {
 
   if (captionArray) {
     captionArray.forEach(function(caption) {
-      this.inbandTextTrack_.addCue(
+      let track = caption.stream;
+
+      this.inbandTextTracks_[track].addCue(
         new Cue(
           caption.startTime + this.timestampOffset,
           caption.endTime + this.timestampOffset,

--- a/src/cleanup-text-tracks.js
+++ b/src/cleanup-text-tracks.js
@@ -26,6 +26,15 @@ export const removeExistingTrack = function(player, kind, label) {
  * @private
  */
 export const cleanupTextTracks = function(player) {
-  removeExistingTrack(player, 'captions', 'cc1');
+  const tracks = player.remoteTextTracks() || [];
+
+  for (let i = tracks.length - 1; i >= 0; i--) {
+    const track = tracks[i];
+
+    if (track.kind === 'captions') {
+      player.removeRemoteTextTrack(track);
+    }
+  }
+
   removeExistingTrack(player, 'metadata', 'Timed Metadata');
 };

--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -179,7 +179,11 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
     // of a buffered-range and everything else is reset on seek
     this.mediaSource_.player_.on('seeked', () => {
       removeCuesFromTrack(0, Infinity, this.metadataTrack_);
-      removeCuesFromTrack(0, Infinity, this.inbandTextTrack_);
+      if (this.inbandTextTracks_) {
+        for (let track in this.inbandTextTracks_) {
+          removeCuesFromTrack(0, Infinity, this.inbandTextTracks_[track]);
+        }
+      }
     });
 
     this.mediaSource_.player_.tech_.hls.on('dispose', () => {
@@ -245,7 +249,11 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
    */
   remove(start, end) {
     removeCuesFromTrack(start, end, this.metadataTrack_);
-    removeCuesFromTrack(start, end, this.inbandTextTrack_);
+    if (this.inbandTextTracks_) {
+      for (let track in this.inbandTextTracks_) {
+        removeCuesFromTrack(start, end, this.inbandTextTracks_[track]);
+      }
+    }
     this.trigger({ type: 'update' });
     this.trigger({ type: 'updateend' });
   }

--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -421,7 +421,11 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
     removeCuesFromTrack(start, end, this.metadataTrack_);
 
     // Remove Any Captions
-    removeCuesFromTrack(start, end, this.inbandTextTrack_);
+    if (this.inbandTextTracks_) {
+      for (let track in this.inbandTextTracks_) {
+        removeCuesFromTrack(start, end, this.inbandTextTracks_[track]);
+      }
+    }
   }
 
   /**

--- a/test/add-text-track-data.test.js
+++ b/test/add-text-track-data.test.js
@@ -15,7 +15,12 @@ class MockTextTrack {
 module('Text Track Data', {
   beforeEach() {
     this.sourceHandler = {
-      inbandTextTrack_: new MockTextTrack(),
+      inbandTextTracks_: {
+        CC1: new MockTextTrack(),
+        CC2: new MockTextTrack(),
+        CC3: new MockTextTrack(),
+        CC4: new MockTextTrack()
+      },
       metadataTrack_: new MockTextTrack(),
       mediaSource_: {
         duration: NaN
@@ -27,17 +32,36 @@ module('Text Track Data', {
 
 test('does nothing if no cues are specified', function() {
   addTextTrackData(this.sourceHandler, [], []);
-  equal(this.sourceHandler.inbandTextTrack_.cues.length, 0, 'added no 608 cues');
+  equal(this.sourceHandler.inbandTextTracks_.CC1.cues.length, 0, 'added no 608 cues');
   equal(this.sourceHandler.metadataTrack_.cues.length, 0, 'added no metadata cues');
 });
 
-test('creates cues for 608 captions', function() {
+test('creates cues for 608 captions with "stream" property in ccX', function() {
   addTextTrackData(this.sourceHandler, [{
     startTime: 0,
     endTime: 1,
-    text: 'caption text'
+    text: 'CC1 text',
+    stream: 'CC1'
+  }, {
+    startTime: 0,
+    endTime: 1,
+    text: 'CC2 text',
+    stream: 'CC2'
+  }, {
+    startTime: 0,
+    endTime: 1,
+    text: 'CC3 text',
+    stream: 'CC3'
+  }, {
+    startTime: 0,
+    endTime: 1,
+    text: 'CC4 text',
+    stream: 'CC4'
   }], []);
-  equal(this.sourceHandler.inbandTextTrack_.cues.length, 1, 'added one 608 cues');
+  equal(this.sourceHandler.inbandTextTracks_.CC1.cues.length, 1, 'added one 608 cue to CC1');
+  equal(this.sourceHandler.inbandTextTracks_.CC2.cues.length, 1, 'added one 608 cue to CC2');
+  equal(this.sourceHandler.inbandTextTracks_.CC3.cues.length, 1, 'added one 608 cue to CC3');
+  equal(this.sourceHandler.inbandTextTracks_.CC4.cues.length, 1, 'added one 608 cue to CC4');
   equal(this.sourceHandler.metadataTrack_.cues.length, 0, 'added no metadata cues');
 });
 
@@ -46,6 +70,6 @@ test('creates cues for timed metadata', function() {
     cueTime: 1,
     frames: [{}]
   }]);
-  equal(this.sourceHandler.inbandTextTrack_.cues.length, 0, 'added no 608 cues');
+  equal(this.sourceHandler.inbandTextTracks_.CC1.cues.length, 0, 'added no 608 cues');
   equal(this.sourceHandler.metadataTrack_.cues.length, 1, 'added one metadata cues');
 });

--- a/test/flash.test.js
+++ b/test/flash.test.js
@@ -69,6 +69,13 @@ const unfakeSTO = function() {
 
 // Create a WebWorker-style message that signals the transmuxer is done
 const createDataMessage = function(data, audioData, metadata, captions) {
+  let captionStreams = {};
+
+  if (captions) {
+    captions.forEach((caption) => {
+      captionStreams[caption.stream] = true;
+    });
+  }
   return {
     data: {
       action: 'data',
@@ -82,7 +89,8 @@ const createDataMessage = function(data, audioData, metadata, captions) {
           }) : []
         },
         metadata,
-        captions
+        captions,
+        captionStreams
       }
     }
   };
@@ -1051,7 +1059,8 @@ QUnit.test('cleans up WebVTT cues on hls dispose', function() {
   let captions = [{
     startTime: 1,
     endTime: 3,
-    text: 'This is an in-band caption'
+    text: 'This is an in-band caption',
+    stream: 'CC1'
   }];
 
   metadata.dispatchType = 0x10;
@@ -1067,6 +1076,11 @@ QUnit.test('cleans up WebVTT cues on hls dispose', function() {
 
       addedTracks.push(trackEl.track);
       return trackEl;
+    },
+    textTracks() {
+      return {
+        getTrackById() {}
+      };
     },
     remoteTextTracks() {
       return addedTracks;


### PR DESCRIPTION
This change supports the work done in https://github.com/videojs/mux.js/pull/150. However, it should be backwards compatible with older mux.js versions.

Rather than `sourceBuffer.inbandTextTrack_` being a single object, it is now `sourceBuffer.inbandTextTracks_`, which is a map that stores `track => object`. When new captions come in, `caption.track` is inspected, and cues are added to the appropriate track. 