### PR TITLE
Updateend events fire more than once on firefox

### DIFF
--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -469,14 +469,12 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
     if (this.videoBuffer_) {
       sortedSegments.video.segments.unshift(sortedSegments.video.initSegment);
       sortedSegments.video.bytes += sortedSegments.video.initSegment.byteLength;
-      this.pendingUpdateEnds_ += 1;
       this.concatAndAppendSegments_(sortedSegments.video, this.videoBuffer_);
       // TODO: are video tracks the only ones with text tracks?
       addTextTrackData(this, sortedSegments.captions, sortedSegments.metadata);
     }
 
     if (!this.audioDisabled_ && this.audioBuffer_) {
-      this.pendingUpdateEnds_ += 1;
       this.concatAndAppendSegments_(sortedSegments.audio, this.audioBuffer_);
     }
 
@@ -508,8 +506,10 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
       });
 
       try {
+        this.pendingUpdateEnds_ += 1;
         destinationBuffer.appendBuffer(tempBuffer);
       } catch (error) {
+        this.pendingUpdateEnds_ -= 1;
         if (this.mediaSource_.player_) {
           this.mediaSource_.player_.error({
             code: -3,

--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -293,7 +293,6 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
       }
 
       let buffer = null;
-      let isSecondary = false;
 
       // If the mediasource already has a SourceBuffer for the codec
       // use that

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -905,7 +905,35 @@ QUnit.test('virtual buffers are updating if either native buffer is', function()
   QUnit.equal(sourceBuffer.updating, true, 'virtual buffer is updating');
 
   mediaSource.audioBuffer_.updating = false;
+  QUnit.equal(sourceBuffer.updating, true, 'virtual buffer is updating');
+
+  // The virtual buffer is still updating because both expected updateend events
+  // have not been received..
+
+  mediaSource.videoBuffer_.trigger('updateend');
+  QUnit.equal(sourceBuffer.updating, true, 'virtual buffer is updating');
+
+  mediaSource.audioBuffer_.trigger('updateend');
   QUnit.equal(sourceBuffer.updating, false, 'virtual buffer is not updating');
+});
+
+QUnit.test('virtual buffers only trigger if all expected updateends have been received', function(assert) {
+  let done = assert.async();
+  let mediaSource = new videojs.MediaSource();
+  let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
+
+  assert.expect(1);
+  initializeNativeSourceBuffers(sourceBuffer);
+
+  sourceBuffer.on('updateend', function() {
+    assert.equal(sourceBuffer.pendingUpdateEnds_, 0, 'No pending UpdateEnd events');
+    done();
+  });
+
+  mediaSource.videoBuffer_.updating = false;
+  mediaSource.audioBuffer_.updating = false;
+  mediaSource.videoBuffer_.trigger('updateend');
+  mediaSource.audioBuffer_.trigger('updateend');
 });
 
 QUnit.test(

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -284,7 +284,7 @@ function() {
   );
 });
 
-QUnit.test('removing works even with audio disabled', function() {
+QUnit.test('removing doesn\'t happen with audio disabled', function() {
   let mediaSource = new videojs.MediaSource();
   let muxedBuffer = mediaSource.addSourceBuffer('video/mp2t');
   // creating this audio buffer disables audio in the muxed one
@@ -317,7 +317,7 @@ QUnit.test('removing works even with audio disabled', function() {
 
   muxedBuffer.remove(3, 10);
 
-  QUnit.equal(removes, 2, 'called remove on both muxedBuffers');
+  QUnit.equal(removes, 1, 'called remove on only one source buffer');
   QUnit.equal(muxedBuffer.inbandTextTrack_.cues.length,
               1,
               'one cue remains after remove');
@@ -905,35 +905,7 @@ QUnit.test('virtual buffers are updating if either native buffer is', function()
   QUnit.equal(sourceBuffer.updating, true, 'virtual buffer is updating');
 
   mediaSource.audioBuffer_.updating = false;
-  QUnit.equal(sourceBuffer.updating, true, 'virtual buffer is updating');
-
-  // The virtual buffer is still updating because both expected updateend events
-  // have not been received..
-
-  mediaSource.videoBuffer_.trigger('updateend');
-  QUnit.equal(sourceBuffer.updating, true, 'virtual buffer is updating');
-
-  mediaSource.audioBuffer_.trigger('updateend');
   QUnit.equal(sourceBuffer.updating, false, 'virtual buffer is not updating');
-});
-
-QUnit.test('virtual buffers only trigger if all expected updateends have been received', function(assert) {
-  let done = assert.async();
-  let mediaSource = new videojs.MediaSource();
-  let sourceBuffer = mediaSource.addSourceBuffer('video/mp2t');
-
-  assert.expect(1);
-  initializeNativeSourceBuffers(sourceBuffer);
-
-  sourceBuffer.on('updateend', function() {
-    assert.equal(sourceBuffer.pendingUpdateEnds_, 0, 'No pending UpdateEnd events');
-    done();
-  });
-
-  mediaSource.videoBuffer_.updating = false;
-  mediaSource.audioBuffer_.updating = false;
-  mediaSource.videoBuffer_.trigger('updateend');
-  mediaSource.audioBuffer_.trigger('updateend');
 });
 
 QUnit.test(


### PR DESCRIPTION
After an append, the SourceBuffer state (the `updating` property) can toggle to `false` long before the `updateend` events are triggered. The checks in `virtual-source-buffer` to "debounce" `updateend` events were inadequate to handle this scenario and would often trigger two `updateend` events instead of just one.

This should fix that scenario.