### PR TITLE
fix: Don't process segments if the mediaSource is closed

### DIFF
--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -263,6 +263,12 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
    * @param {Event} event the done event from the transmuxer
    */
   done_(event) {
+    // Don't process and append data if the mediaSource is closed
+    if (this.mediaSource_.readyState === 'closed') {
+      this.pendingBuffers_.length = 0;
+      return;
+    }
+
     // All buffers should have been flushed from the muxer
     // start processing anything we have received
     this.processPendingSegments_();


### PR DESCRIPTION
In certain situations we might try to append segment data when the mediaSource is closed.

Todo: add tests