### PR TITLE
Fix disabled audio for a single audio only source buffer

### DIFF
--- a/src/flash-media-source.js
+++ b/src/flash-media-source.js
@@ -72,7 +72,7 @@ export default class FlashMediaSource extends videojs.EventTarget {
     let sourceBuffer;
 
     // if this is an FLV type, we'll push data to flash
-    if (parsedType.type === 'video/mp2t') {
+    if (parsedType.type === 'video/mp2t' || parsedType.type === 'audio/mp2t') {
       // Flash source buffers
       sourceBuffer = new FlashSourceBuffer(this);
     } else {

--- a/test/flash.test.js
+++ b/test/flash.test.js
@@ -230,6 +230,11 @@ QUnit.test('creates FlashSourceBuffers for video/mp2t', function() {
       'create source buffer');
 });
 
+QUnit.test('creates FlashSourceBuffers for audio/mp2t', function() {
+  QUnit.ok(this.mediaSource.addSourceBuffer('audio/mp2t') instanceof FlashSourceBuffer,
+      'create source buffer');
+});
+
 QUnit.test('waits for the next tick to append', function() {
   let sourceBuffer = this.mediaSource.addSourceBuffer('video/mp2t');
 

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -1467,7 +1467,42 @@ function() {
     'active source buffers starts with combined source buffer');
   QUnit.equal(mediaSource.activeSourceBuffers[1], sourceBufferAudio,
     'active source buffers ends with audio source buffer');
+});
 
+QUnit.test('Single buffer always active. Audio disabled depends on audio codec',
+function() {
+  let mediaSource = new videojs.MediaSource();
+  let audioTracks = [{
+    enabled: true,
+    kind: 'main',
+    label: 'main'
+  }];
+
+  this.player.audioTracks = () => audioTracks;
+
+  mediaSource.player_ = this.player;
+
+  let sourceBuffer = mediaSource.addSourceBuffer('video/m2pt');
+
+  // video only
+  sourceBuffer.videoCodec_ = true;
+  sourceBuffer.audioCodec_ = false;
+
+  mediaSource.updateActiveSourceBuffers_();
+
+  QUnit.equal(mediaSource.activeSourceBuffers.length, 1, 'sourceBuffer is active');
+  QUnit.ok(mediaSource.activeSourceBuffers[0].audioDisabled_,
+    'audio is disabled on video only active sourceBuffer');
+
+  // audio only
+  sourceBuffer.videoCodec_ = false;
+  sourceBuffer.audioCodec_ = true;
+
+  mediaSource.updateActiveSourceBuffers_();
+
+  QUnit.equal(mediaSource.activeSourceBuffers.length, 1, 'sourceBuffer is active');
+  QUnit.notOk(mediaSource.activeSourceBuffers[0].audioDisabled_,
+    'audio not disabled on audio only active sourceBuffer');
 });
 
 QUnit.test('video segments with info trigger videooinfo event', function() {


### PR DESCRIPTION
When loading an audio only playlist, we would create a single source buffer that had only audio codecs. When changes to the audio tracks happen, the `HtmlMediaSource` would update which source buffer has ownership of audio. When the `main` audio track is enabled, we used the assumption that audio is muxed into the main playlist, and alternate audio is not being used, so audio would be enabled in the "combined" source buffer, and disabled in the "audio only" source buffer. However, in the case of audio only playlist, the "combined" source buffer would only have an audio codec, which was incorrectly being marked as the "audio only" source buffer, so audio would be disabled and prevent data from ever being appended.

This problem was hidden by a race condition between contrib-hls `MasterPlaylistController` completing the first media playlist request and the `MediaSource` triggering the `sourceopen` event. If the `sourceopen` event happened second, the audio track change event listeners would be setup later, avoiding this bug.

This change checks to see if there is only one source buffer, and if so make sure it is always active and enables audio based on the source buffer's audio codec information.

Addresses:
https://github.com/videojs/videojs-contrib-hls/issues/1186
https://github.com/videojs/videojs-contrib-hls/issues/1179

Audio only in Flash also has some issues when we detect that the type is `audio/mp2t`. This address that by allowing audio only `FlashSourceBuffer`s to be created.