### PR TITLE
Append video data at end of buffer in HTML mode for IE11 for safe quality switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   ],
   "dependencies": {
     "global": "^4.3.0",
-    "mux.js": "4.2.1",
+    "mux.js": "4.3.0",
     "video.js": "^5.17.0",
     "webworkify": "1.0.2"
   },

--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -188,6 +188,8 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
 
     let onHlsReset = this.onHlsReset_.bind(this);
 
+    // hls-reset is fired by videojs.Hls on to the tech after the main SegmentLoader
+    // resets its state and flushes the buffer
     this.mediaSource_.player_.tech_.on('hls-reset', onHlsReset);
 
     this.mediaSource_.player_.tech_.hls.on('dispose', () => {

--- a/src/html-media-source.js
+++ b/src/html-media-source.js
@@ -191,7 +191,12 @@ export default class HtmlMediaSource extends videojs.EventTarget {
 
       this.player_ = videojs(video.parentNode);
 
+      // hls-reset is fired by videojs.Hls on to the tech after the main SegmentLoader
+      // resets its state and flushes the buffer
       this.player_.tech_.on('hls-reset', this.onHlsReset_);
+      // hls-segment-time-mapping is fired by videojs.Hls on to the tech after the main
+      // SegmentLoader inspects an MTS segment and has an accurate stream to display
+      // time mapping
       this.player_.tech_.on('hls-segment-time-mapping', this.onHlsSegmentTimeMapping_);
 
       if (this.player_.audioTracks && this.player_.audioTracks()) {

--- a/src/html-media-source.js
+++ b/src/html-media-source.js
@@ -166,6 +166,10 @@ export default class HtmlMediaSource extends videojs.EventTarget {
       });
     };
 
+    this.onHlsSegmentTimeMapping_ = (event) => {
+      this.sourceBuffers.forEach(buffer => buffer.timeMapping_ = event.mapping);
+    };
+
     // Re-emit MediaSource events on the polyfill
     [
       'sourceopen',
@@ -188,6 +192,7 @@ export default class HtmlMediaSource extends videojs.EventTarget {
       this.player_ = videojs(video.parentNode);
 
       this.player_.tech_.on('hls-reset', this.onHlsReset_);
+      this.player_.tech_.on('hls-segment-time-mapping', this.onHlsSegmentTimeMapping_);
 
       if (this.player_.audioTracks && this.player_.audioTracks()) {
         this.player_.audioTracks().on('change', this.updateActiveSourceBuffers_);
@@ -238,6 +243,7 @@ export default class HtmlMediaSource extends videojs.EventTarget {
       if (this.player_.el_) {
         this.player_.off('mediachange', this.onPlayerMediachange_);
         this.player_.tech_.off('hls-reset', this.onHlsReset_);
+        this.player_.tech_.off('hls-segment-time-mapping', this.onHlsSegmentTimeMapping_);
       }
     });
   }

--- a/src/transmuxer-worker.js
+++ b/src/transmuxer-worker.js
@@ -59,6 +59,13 @@ const wireTransmuxerEvents = function(transmuxer) {
   transmuxer.on('done', function(data) {
     window.postMessage({ action: 'done' });
   });
+
+  transmuxer.on('gopInfo', function(gopInfo) {
+    window.postMessage({
+      action: 'gopInfo',
+      gopInfo
+    });
+  });
 };
 
 /**
@@ -137,6 +144,9 @@ class MessageHandlers {
     this.transmuxer.resetCaptions();
   }
 
+  alignGopsWith(data) {
+    this.transmuxer.alignGopsWith(data.gopsToAlignWith.slice());
+  }
 }
 
 /**

--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -103,9 +103,7 @@ export const updateGopBuffer = (buffer, gops, replace) => {
     }
   }
 
-  i = i % buffer.length;
-
-  return buffer.slice(i).concat(gops);
+  return buffer.slice(0, i).concat(gops);
 };
 
 /**
@@ -550,8 +548,6 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
    *        List of gop info to append
    */
   appendGopInfo_(event) {
-    const gopInfo = event.data.gopInfo;
-
     this.gopBuffer_ = updateGopBuffer(this.gopBuffer_,
                                       event.data.gopInfo,
                                       this.safeAppend_);

--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -688,12 +688,12 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
 
     this.pendingBuffers_.length = 0;
 
-    // We are no longer in the internal "updating" state
-    this.bufferUpdating_ = false;
-
     if (triggerUpdateend) {
       this.trigger('updateend');
     }
+
+    // We are no longer in the internal "updating" state
+    this.bufferUpdating_ = false;
   }
 
   /**

--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -105,9 +105,7 @@ export const updateGopBuffer = (buffer, gops, replace) => {
 
   i = i % buffer.length;
 
-  updatedBuffer = buffer.slice(i);
-
-  return updatedBuffer.concat(gops);
+  return buffer.slice(i).concat(gops);
 };
 
 /**
@@ -122,7 +120,7 @@ export const updateGopBuffer = (buffer, gops, replace) => {
  * @param {Double} mapping
  *        Offset to map display time to stream presentation time
  */
-export const removeGopInfo = (buffer, start, end, mapping) => {
+export const removeGopBuffer = (buffer, start, end, mapping) => {
   const startPts = Math.ceil((start - mapping) * 90000);
   const endPts = Math.ceil((end - mapping) * 90000);
   const updatedBuffer = buffer.slice();
@@ -571,7 +569,7 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
     if (this.videoBuffer_) {
       this.videoBuffer_.updating = true;
       this.videoBuffer_.remove(start, end);
-      this.gopBuffer_ = removeGopInfo(this.gopBuffer_, start, end, this.timeMapping_);
+      this.gopBuffer_ = removeGopBuffer(this.gopBuffer_, start, end, this.timeMapping_);
     }
     if (!this.audioDisabled_ && this.audioBuffer_) {
       this.audioBuffer_.updating = true;

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -4,6 +4,11 @@ import QUnit from 'qunit';
 import sinon from 'sinon';
 import videojs from 'video.js';
 import HtmlMediaSource from '../src/html-media-source';
+import {
+  gopsSafeToAlignWith,
+  updateGopBuffer,
+  removeGopBuffer
+} from '../src/virtual-source-buffer';
 
 // we disable this because browserify needs to include these files
 // but the exports are not important
@@ -1529,4 +1534,426 @@ QUnit.test('creates native SourceBuffers immediately if a second ' +
   QUnit.ok(
     sourceBuffer2.audioBuffer_,
     'second source buffer has an audio source buffer');
+});
+
+QUnit.module('VirtualSourceBuffer - Isolated Functions');
+
+QUnit.test('gopsSafeToAlignWith returns correct list', function() {
+  // gopsSafeToAlignWith uses a 3 second safetyNet so that gops very close to the playhead
+  // are not considered safe to append to
+  const safetyNet = 3;
+  const pts = (time) => Math.ceil(time * 90000);
+  let mapping = 0;
+  let currentTime = 0;
+  let buffer = [];
+  let player;
+  let actual;
+  let expected;
+
+  expected = [];
+  actual = gopsSafeToAlignWith(buffer, player, mapping);
+  QUnit.deepEqual(actual, expected, 'empty array when player is undefined');
+
+  player = { currentTime: () => currentTime };
+  actual = gopsSafeToAlignWith(buffer, player, mapping);
+  QUnit.deepEqual(actual, expected, 'empty array when buffer is empty');
+
+  buffer = expected = [
+    { pts: pts(currentTime + safetyNet + 1) },
+    { pts: pts(currentTime + safetyNet + 2) },
+    { pts: pts(currentTime + safetyNet + 3) }
+  ];
+  actual = gopsSafeToAlignWith(buffer, player, mapping);
+  QUnit.deepEqual(actual, expected,
+    'entire buffer considered safe when all gops come after currentTime + safetyNet');
+
+  buffer = [
+    { pts: pts(currentTime + safetyNet) },
+    { pts: pts(currentTime + safetyNet + 1) },
+    { pts: pts(currentTime + safetyNet + 2) }
+  ];
+  expected = [
+    { pts: pts(currentTime + safetyNet + 1) },
+    { pts: pts(currentTime + safetyNet + 2) }
+  ];
+  actual = gopsSafeToAlignWith(buffer, player, mapping);
+  QUnit.deepEqual(actual, expected, 'safetyNet comparison is not inclusive');
+
+  currentTime = 10;
+  mapping = -5;
+  buffer = [
+    { pts: pts(currentTime - mapping + safetyNet - 2) },
+    { pts: pts(currentTime - mapping + safetyNet - 1) },
+    { pts: pts(currentTime - mapping + safetyNet) },
+    { pts: pts(currentTime - mapping + safetyNet + 1) },
+    { pts: pts(currentTime - mapping + safetyNet + 2) }
+  ];
+  expected = [
+    { pts: pts(currentTime - mapping + safetyNet + 1) },
+    { pts: pts(currentTime - mapping + safetyNet + 2) }
+  ];
+  actual = gopsSafeToAlignWith(buffer, player, mapping);
+  QUnit.deepEqual(actual, expected, 'uses mapping to shift currentTime');
+
+  currentTime = 20;
+  expected = [];
+  actual = gopsSafeToAlignWith(buffer, player, mapping);
+  QUnit.deepEqual(actual, expected,
+    'empty array when no gops in buffer come after currentTime');
+});
+
+QUnit.test('updateGopBuffer correctly processes new gop information', function() {
+  let buffer = [];
+  let gops = [];
+  let replace = true;
+  let actual;
+  let expected;
+
+  buffer = expected = [{ pts: 100 }, { pts: 200 }];
+  actual = updateGopBuffer(buffer, gops, replace);
+  QUnit.deepEqual(actual, expected, 'returns buffer when no new gops');
+
+  gops = expected = [{ pts: 300 }, { pts: 400 }];
+  actual = updateGopBuffer(buffer, gops, replace);
+  QUnit.deepEqual(actual, expected, 'returns only new gops when replace is true');
+
+  replace = false;
+  buffer = [];
+  gops = [{ pts: 100 }];
+  expected = [{ pts: 100 }];
+  actual = updateGopBuffer(buffer, gops, replace);
+  QUnit.deepEqual(actual, expected, 'appends new gops to empty buffer');
+
+  buffer = [{ pts: 100 }, { pts: 200 }];
+  gops = [{ pts: 300 }, { pts: 400 }];
+  expected = [{ pts: 100 }, { pts: 200 }, { pts: 300 }, { pts: 400 }];
+  actual = updateGopBuffer(buffer, gops, replace);
+  QUnit.deepEqual(actual, expected, 'appends new gops at end of buffer when no overlap');
+
+  buffer = [{ pts: 100 }, { pts: 200 }, { pts: 300 }, { pts: 400 }];
+  gops = [{ pts: 250 }, { pts: 300 }, { pts: 350 }];
+  expected = [{ pts: 100 }, { pts: 200 }, { pts: 250 }, { pts: 300 }, { pts: 350 }];
+  actual = updateGopBuffer(buffer, gops, replace);
+  QUnit.deepEqual(actual, expected,
+    'slices buffer at point of overlap and appends new gops');
+
+  buffer = [{ pts: 100 }, { pts: 200 }, { pts: 300 }, { pts: 400 }];
+  gops = [{ pts: 200 }, { pts: 300 }, { pts: 350 }];
+  expected = [{ pts: 100 }, { pts: 200 }, { pts: 300 }, { pts: 350 }];
+  actual = updateGopBuffer(buffer, gops, replace);
+  QUnit.deepEqual(actual, expected, 'overlap slice is inclusive');
+
+  buffer = [{ pts: 300 }, { pts: 400 }, { pts: 500 }, { pts: 600 }];
+  gops = [{ pts: 100 }, { pts: 200 }, { pts: 250 }];
+  expected = [{ pts: 100 }, { pts: 200 }, { pts: 250 }];
+  actual = updateGopBuffer(buffer, gops, replace);
+  QUnit.deepEqual(actual, expected,
+    'completely replaces buffer with new gops when all gops come before buffer');
+});
+
+QUnit.test('removeGopBuffer correctly removes range from buffer', function() {
+  const pts = (time) => Math.ceil(time * 90000);
+  let buffer = [];
+  let start = 0;
+  let end = 0;
+  let mapping = -5;
+  let actual;
+  let expected;
+
+  expected = [];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected, 'returns empty array when buffer empty');
+
+  start = 0;
+  end = 8;
+  buffer = expected = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected,
+    'no removal when remove range comes before start of buffer');
+
+  start = 22;
+  end = 30;
+  buffer = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  expected = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) }
+  ];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected,
+    'removes last gop when remove range is after end of buffer');
+
+  start = 0;
+  end = 10;
+  buffer = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  expected = [
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected, 'clamps start range to begining of buffer');
+
+  start = 0;
+  end = 12;
+  buffer = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  expected = [
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected, 'clamps start range to begining of buffer');
+
+  start = 0;
+  end = 14;
+  buffer = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  expected = [
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected, 'clamps start range to begining of buffer');
+
+  start = 15;
+  end = 30;
+  buffer = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  expected = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) }
+  ];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected, 'clamps end range to end of buffer');
+
+  start = 17;
+  end = 30;
+  buffer = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  expected = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) }
+  ];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected, 'clamps end range to end of buffer');
+
+  start = 20;
+  end = 30;
+  buffer = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  expected = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) }
+  ];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected, 'clamps end range to end of buffer');
+
+  buffer = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  start = 12;
+  end = 15;
+  expected = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected, 'removes gops that remove range intersects with');
+
+  buffer = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  start = 12;
+  end = 14;
+  expected = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected, 'removes gops that remove range intersects with');
+
+  buffer = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  start = 13;
+  end = 14;
+  expected = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected, 'removes gops that remove range intersects with');
+
+  buffer = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  start = 13;
+  end = 15;
+  expected = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected, 'removes gops that remove range intersects with');
+
+  buffer = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  start = 12;
+  end = 17;
+  expected = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected, 'removes gops that remove range intersects with');
+
+  buffer = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  start = 13;
+  end = 16;
+  expected = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected, 'removes gops that remove range intersects with');
+
+  start = 10;
+  end = 20;
+  buffer = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  expected = [];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected,
+    'removes entire buffer when buffer inside remove range');
+
+  start = 0;
+  end = 30;
+  buffer = [
+    { pts: pts(10 - mapping) },
+    { pts: pts(11 - mapping) },
+    { pts: pts(12 - mapping) },
+    { pts: pts(15 - mapping) },
+    { pts: pts(18 - mapping) },
+    { pts: pts(20 - mapping) }
+  ];
+  expected = [];
+  actual = removeGopBuffer(buffer, start, end, mapping);
+  QUnit.deepEqual(actual, expected,
+    'removes entire buffer when buffer inside remove range');
 });


### PR DESCRIPTION
## Description
Some browsers (cough IE11 and Edge cough) have a more simple, though still spec compliant, implementation of MediaSourceExtensions compared to other browsers. The main issue with this simpler implementation is that MSE will drop data until the next key frame that comes after the time already sent to the decoder. What this means is you cannot append content that overlaps with the playhead (something videojs-contrib-hls relies on for faster mid-segment quality switching) without the risk of visual corruption since the frames needed to decode the new content at the playhead are dropped before being sent to the decoder.

REQUIRES THE FOLLOWING FOR FULL SUPPORT
https://github.com/videojs/mux.js/pull/162
https://github.com/videojs/videojs-contrib-hls/pull/1259

## Specific Changes proposed
 * The `VirtualSourceBuffer` will now keep track of the timing information of the GOPs within the segments it appends to the media source buffer. It will inform the transmuxer before transmuxing each segment of a list of time values considered "safe" to append. This will prevent appended video data that overlaps with the playhead while also making sure data is aligned on GOP boundaries to make sure the decoder always has enough information to decode whats appended
  * In IE11, a "safe append" mode is used, which tries to append as close to the end of the buffer as possible, instead of as close to the playhead as possible. This further helps prevent the visual corruption seen in IE11 since it needs to append data past what MSE has already sent to the decoder instead of just data that is past the playhead.