### PR TITLE
fix Safari 9.x.x can not find this keyword in Worker

### DIFF
--- a/src/transmuxer-worker.js
+++ b/src/transmuxer-worker.js
@@ -149,17 +149,17 @@ class MessageHandlers {
 const TransmuxerWorker = function(self) {
   self.onmessage = function(event) {
     if (event.data.action === 'init' && event.data.options) {
-      this.messageHandlers = new MessageHandlers(event.data.options);
+      self.messageHandlers = new MessageHandlers(event.data.options);
       return;
     }
 
-    if (!this.messageHandlers) {
-      this.messageHandlers = new MessageHandlers();
+    if (!self.messageHandlers) {
+      self.messageHandlers = new MessageHandlers();
     }
 
     if (event.data && event.data.action && event.data.action !== 'init') {
-      if (this.messageHandlers[event.data.action]) {
-        this.messageHandlers[event.data.action](event.data);
+      if (self.messageHandlers[event.data.action]) {
+        self.messageHandlers[event.data.action](event.data);
       }
     }
   };


### PR DESCRIPTION
In Safari 9.x.x, The follow statement will get an error:
```
this.messageHandlers = new MessageHandlers(event.data.options);
```
`this` need to be changed to `self`

sorry for my poor english.