### PR TITLE
update mux.js to 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13754,9 +13754,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-4.3.0.tgz",
-      "integrity": "sha512-QTS3OINAFT8wR8Gw52AS1enrKe8EpvT942MUILbHsQnAaQBWrbnMKF4MvfBoNeXjwZLswLOEIVOGsHyqRsMarA=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-4.3.1.tgz",
+      "integrity": "sha512-Ups1dVqPx3kYhsi72HJFfESqHnxJcy2XKjjuXRwxbEeu/2G7s3of1azQSdJx91sMcwRl7kcwUMXVYi2Gmlge6A=="
     },
     "nodemon": {
       "version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   ],
   "dependencies": {
     "global": "^4.3.0",
-    "mux.js": "4.3.0",
+    "mux.js": "4.3.1",
     "video.js": "^5.17.0",
     "webworkify": "1.0.2"
   },


### PR DESCRIPTION
* Set active data channel per-field instead of globally for CEA-608
  * Fixed an issue with captions being placed in the wrong CC