### PR TITLE
Update video.js dependency to allow for v6 to be installed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "global": "^4.3.0",
     "mux.js": "4.3.2",
-    "video.js": "^5.17.0",
+    "video.js": "^5.17.0 || ^6.2.0",
     "webworkify": "1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This is based on the same dep pattern that videojs-contrib-hls uses.
With this update, when external projects decide to use video.js v6,
there won't end up being 2 copies bundled into the output.

Closes: videojs/videojs-contrib-media-sources#167