### PR TITLE
use webwackify for webworkers to support webpack bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25575,10 +25575,10 @@
         }
       }
     },
-    "webworkify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/webworkify/-/webworkify-1.0.2.tgz",
-      "integrity": "sha1-thapWmIlJJvyWpHpbglCxmUVWZU="
+    "webwackify": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/webwackify/-/webwackify-0.1.3.tgz",
+      "integrity": "sha512-ttgVaQAd+9kYmZxgAuP8LMlYQRwDa8CujTEIxjXzb/XzMkF9Rg5jN7J4tus1kJvFHeINDa0MlM3pZqR+iRmkAg=="
     },
     "which": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "global": "^4.3.0",
     "mux.js": "4.3.2",
     "video.js": "^5.17.0 || ^6.2.0",
-    "webworkify": "1.0.2"
+    "webwackify": "0.1.3"
   },
   "devDependencies": {
     "babel": "^5.8.0",

--- a/src/flash-source-buffer.js
+++ b/src/flash-source-buffer.js
@@ -8,8 +8,20 @@ import removeCuesFromTrack from './remove-cues-from-track';
 import createTextTracksIfNecessary from './create-text-tracks-if-necessary';
 import {addTextTrackData} from './add-text-track-data';
 import transmuxWorker from './flash-transmuxer-worker';
-import work from 'webworkify';
+import work from 'webwackify';
 import FlashConstants from './flash-constants';
+
+const resolveFlashTransmuxWorker = () => {
+  let result;
+
+  try {
+    result = require.resolve('./flash-transmuxer-worker');
+  } catch (e) {
+    // no result
+  }
+
+  return result;
+};
 
 /**
  * A wrapper around the setTimeout function that uses
@@ -125,7 +137,7 @@ export default class FlashSourceBuffer extends videojs.EventTarget {
 
     this.mediaSource_.swfObj.vjs_appendChunkReady(this.flashEncodedHeaderName_);
 
-    this.transmuxer_ = work(transmuxWorker);
+    this.transmuxer_ = work(transmuxWorker, resolveFlashTransmuxWorker());
     this.transmuxer_.postMessage({ action: 'init', options: {} });
     this.transmuxer_.onmessage = (event) => {
       if (event.data.action === 'data') {

--- a/src/virtual-source-buffer.js
+++ b/src/virtual-source-buffer.js
@@ -5,9 +5,21 @@ import videojs from 'video.js';
 import createTextTracksIfNecessary from './create-text-tracks-if-necessary';
 import removeCuesFromTrack from './remove-cues-from-track';
 import {addTextTrackData} from './add-text-track-data';
-import work from 'webworkify';
+import work from 'webwackify';
 import transmuxWorker from './transmuxer-worker';
 import {isAudioCodec, isVideoCodec} from './codec-utils';
+
+const resolveTransmuxWorker = () => {
+  let result;
+
+  try {
+    result = require.resolve('./transmuxer-worker');
+  } catch (e) {
+    // no result
+  }
+
+  return result;
+};
 
 // We create a wrapper around the SourceBuffer so that we can manage the
 // state of the `updating` property manually. We have to do this because
@@ -197,7 +209,7 @@ export default class VirtualSourceBuffer extends videojs.EventTarget {
 
     // append muxed segments to their respective native buffers as
     // soon as they are available
-    this.transmuxer_ = work(transmuxWorker);
+    this.transmuxer_ = work(transmuxWorker, resolveTransmuxWorker());
     this.transmuxer_.postMessage({action: 'init', options });
 
     this.transmuxer_.onmessage = (event) => {


### PR DESCRIPTION
Regarding the `require.resolve`:

webpack resolves module names to ids during compile time. One of the issues with webworkify-webpack-dropin was that it used regex to search for the `require` statements to get the resolved module id so it could properly setup the bootstrapfn to start at the right module. This broke in some cases with minification because the regex would get messed up. By passing the module id directly from require.resolve, you dont have to do any of the regex work, and can just build the entire module list and have the starting id given to you. This problem is described in more detail here https://github.com/videojs/videojs-contrib-hls/issues/600#issuecomment-293550845