### PR TITLE
docs: removing maintainers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ A [Media Source Extensions](https://dvcs.w3.org/hg/html-media/raw-file/tip/media
 Media Source Extensions (MSE) is a W3C draft specification that makes it possible to feed data directly to a video element.
 MSE allows video developers to build functionality like adaptive streaming directly in javascript.
 
-Lead Maintainer: Jon-Carlos Rivera [@imbcmdth](https://github.com/imbcmdth)
-
 Maintenance Status: Stable
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->


### PR DESCRIPTION
Removing the maintainers section since the video.js playback team maintains this repo